### PR TITLE
Remove argparse and adjust arguments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ If you have not pre-computed the VAE and CLIP latents for your dataset, set `pre
 
 Once the configurations have been updated, start training at 256x256 resolution by running:
 ```
-composer run.py --config_path yamls/hydra-yamls --config_name SD-2-base-256.yaml
+composer run.py --config-path yamls/hydra-yamls --config-name SD-2-base-256.yaml
 ```
 Next, start training at 512x512 resolution by running:
 ```
-composer run.py --config_path yamls/hydra-yamls --config_name SD-2-base-512.yaml
+composer run.py --config-path yamls/hydra-yamls --config-name SD-2-base-512.yaml
 ```
 
 # Online Eval

--- a/run.py
+++ b/run.py
@@ -15,7 +15,8 @@ from diffusion.train import train
 def main(config: DictConfig) -> None:
     """Hydra wrapper for train."""
     if not config:
-        raise ValueError(textwrap.dedent("""\
+        raise ValueError(
+            textwrap.dedent("""\
                             Config path and name not specified!
                             Please specify these by using --config-path and --config-name, respectively."""))
     return train(config)

--- a/run.py
+++ b/run.py
@@ -3,22 +3,21 @@
 
 """Run training."""
 
-import argparse
+import textwrap
 
 import hydra
 from omegaconf import DictConfig
 
 from diffusion.train import train
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--config_path', type=str, default='/mnt/config')
-parser.add_argument('--config_name', type=str, default='parameters')
-args = parser.parse_args()
 
-
-@hydra.main(version_base=None, config_path=args.config_path, config_name=args.config_name)
+@hydra.main(version_base=None)
 def main(config: DictConfig) -> None:
     """Hydra wrapper for train."""
+    if not config:
+        raise ValueError(textwrap.dedent("""\
+                            Config path and name not specified!
+                            Please specify these by using --config-path and --config-name, respectively."""))
     return train(config)
 
 


### PR DESCRIPTION
Fixes #10. Hydra has it's own built-in argparse to process the config path and arguments automatically. 