### PR TITLE
Pass attention mask to CLIP model

### DIFF
--- a/diffusion/datasets/coco/coco_captions.py
+++ b/diffusion/datasets/coco/coco_captions.py
@@ -86,8 +86,8 @@ class StreamingCOCOCaption(StreamingDataset):
             captions = random.sample(sample['captions'], k=1)[0]
         else:
             raise ValueError(f'Invalid caption selection: {self.caption_selection}. Must be one of [random, first].')
-        captions = self.tokenizer(captions, padding='max_length', truncation=True, return_tensors='pt')['input_ids'][0]
-        return {'image': image, 'captions': captions}
+        tokenized = self.tokenizer(captions, padding='max_length', truncation=True, return_tensors='pt')
+        return {'image': image, 'captions': tokenized['input_ids'][0], 'attention_mask': tokenized['attention_mask'][0]}
 
 
 def build_streaming_cocoval_dataloader(

--- a/diffusion/datasets/laion/laion.py
+++ b/diffusion/datasets/laion/laion.py
@@ -97,9 +97,10 @@ class StreamingLAIONDataset(StreamingDataset):
             padding='max_length',
             max_length=self.tokenizer.model_max_length,
             truncation=True,
-        )['input_ids']
-        tokenized_caption = torch.tensor(tokenized_caption)
-        out = {'image': img, 'captions': tokenized_caption}
+        )
+        input_ids = torch.tensor(tokenized_caption['input_ids'])
+        attention_mask = torch.tensor(tokenized_caption['attention_mask'])
+        out = {'image': img, 'captions': input_ids, 'attention_mask': attention_mask}
         if 'caption_latents' in sample:
             out['caption_latents'] = torch.from_numpy(
                 np.frombuffer(sample['caption_latents'], dtype=np.float16).copy()).reshape(77, 1024)

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -158,7 +158,6 @@ class StableDiffusion(ComposerModel):
             latents, conditioning = batch[self.image_latents_key], batch[self.text_latents_key]
         else:
             inputs, conditioning = batch[self.image_key], batch[self.text_key]
-            # Do we need this?
             conditioning = conditioning.view(-1, conditioning.shape[-1])
             attention_mask = None
             if 'attention_mask' in batch:

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -157,10 +157,12 @@ class StableDiffusion(ComposerModel):
         if self.precomputed_latents and self.image_latents_key in batch and self.text_latents_key in batch:
             latents, conditioning = batch[self.image_latents_key], batch[self.text_latents_key]
         else:
-            inputs, conditioning, attention_mask = batch[self.image_key], batch[self.text_key], batch['attention_mask']
-            # Do we need these?
+            inputs, conditioning = batch[self.image_key], batch[self.text_key]
+            # Do we need this?
             conditioning = conditioning.view(-1, conditioning.shape[-1])
-            attention_mask = attention_mask.view(-1, attention_mask.shape[-1])
+            attention_mask = None
+            if 'attention_mask' in batch:
+                attention_mask = batch['attention_mask'].view(-1, batch['attention_mask'].shape[-1])
             if self.encode_latents_in_fp16:
                 # Disable autocast context as models are in fp16
                 with torch.cuda.amp.autocast(enabled=False):


### PR DESCRIPTION
Adds the attention mask as a return value in the LAION and COCO dataloaders. The attention mask is passed to the CLIP model in both `forward()` and `_prepare_text_embeddings()` functions. This will prevent the CLIP model from attending to the padded embeddings.

Convergence impact TBD

I did not add this to the LogDiffusionImage callback yet to keep the PR small. 

As of now, the attention mask passed to the U-Net forward is not used, but this PR seems to be close to adding it to the cross attention layers: https://github.com/huggingface/diffusers/pull/2634. I might try it 😁 