### PR TITLE
Fix readme slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h2><p align="center">Stable Diffusion Training with MosaicML</p></h2>
 
 <p align="center">
-    <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-w0tiddn9-WGTlRpfjcO9J5jyrMub1dg">
+    <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-1btms90mc-GipE2ufuPkKY0QBrmF3LSA">
         <img alt="Chat @ Slack" src="https://img.shields.io/badge/slack-chat-2eb67d.svg?logo=slack">
     </a>
     <a href="https://github.com/mosaicml/examples/blob/main/LICENSE">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 
-This repo contains code used to train your own Stable Diffusion model on your own data.
+This repo contains code used to train your own Stable Diffusion model on your own data
 
 <p align="center">
   <picture>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 
-This repo contains code used to train your own Stable Diffusion model on your own data
+This repo contains code used to train your own Stable Diffusion model on your own data.
 
 <p align="center">
   <picture>


### PR DESCRIPTION
the previous slack link required a `@mosaicml.com` email