### PR TITLE
Update Slack link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h2><p align="center">Stable Diffusion Training with MosaicML</p></h2>
 
 <p align="center">
-    <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-1btms90mc-GipE2ufuPkKY0QBrmF3LSA">
+    <a href="https://mosaicml.me/slack">
         <img alt="Chat @ Slack" src="https://img.shields.io/badge/slack-chat-2eb67d.svg?logo=slack">
     </a>
     <a href="https://github.com/mosaicml/examples/blob/main/LICENSE">


### PR DESCRIPTION
Currently changing the public facing community slack links to : https://mosaicml.me/slack

We used a URL shortener so that if the Slack link dies on us we don't have to change all the slack links everywhere.

Please check if this works (in incognito)