### PR TITLE
Add option to set the prediction type for stable diffusion

### DIFF
--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -89,9 +89,15 @@ def stable_diffusion_2(
 
     tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
-    noise_scheduler.prediction_type = prediction_type
-    inference_noise_scheduler = DDIMScheduler.from_pretrained(model_name, subfolder='scheduler')
-    inference_noise_scheduler.prediction_type = prediction_type
+    inference_noise_scheduler = DDIMScheduler(
+                                    num_train_timesteps=noise_scheduler.config.num_train_timesteps,
+                                    beta_start=noise_scheduler.config.beta_start,
+                                    beta_end=noise_scheduler.config.beta_end,
+                                    beta_schedule=noise_scheduler.config.beta_schedule,
+                                    trained_betas=noise_scheduler.config.trained_betas,
+                                    clip_sample=noise_scheduler.config.clip_sample,
+                                    set_alpha_to_one=noise_scheduler.config.set_alpha_to_one,
+                                    prediction_type=prediction_type)
 
     model = StableDiffusion(
         unet=unet,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -89,15 +89,14 @@ def stable_diffusion_2(
 
     tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
-    inference_noise_scheduler = DDIMScheduler(
-                                    num_train_timesteps=noise_scheduler.config.num_train_timesteps,
-                                    beta_start=noise_scheduler.config.beta_start,
-                                    beta_end=noise_scheduler.config.beta_end,
-                                    beta_schedule=noise_scheduler.config.beta_schedule,
-                                    trained_betas=noise_scheduler.config.trained_betas,
-                                    clip_sample=noise_scheduler.config.clip_sample,
-                                    set_alpha_to_one=noise_scheduler.config.set_alpha_to_one,
-                                    prediction_type=prediction_type)
+    inference_noise_scheduler = DDIMScheduler(num_train_timesteps=noise_scheduler.config.num_train_timesteps,
+                                              beta_start=noise_scheduler.config.beta_start,
+                                              beta_end=noise_scheduler.config.beta_end,
+                                              beta_schedule=noise_scheduler.config.beta_schedule,
+                                              trained_betas=noise_scheduler.config.trained_betas,
+                                              clip_sample=noise_scheduler.config.clip_sample,
+                                              set_alpha_to_one=noise_scheduler.config.set_alpha_to_one,
+                                              prediction_type=prediction_type)
 
     model = StableDiffusion(
         unet=unet,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -28,6 +28,7 @@ except:
 def stable_diffusion_2(
     model_name: str = 'stabilityai/stable-diffusion-2-base',
     pretrained: bool = True,
+    prediction_type: str = 'epsilon',
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     val_guidance_scales: Optional[List] = None,
@@ -45,6 +46,8 @@ def stable_diffusion_2(
     Args:
         model_name (str, optional): Name of the model to load. Defaults to 'stabilityai/stable-diffusion-2-base'.
         pretrained (bool, optional): Whether to load pretrained weights. Defaults to True.
+        prediction_type (str): The type of prediction to use. Must be one of 'sample',
+            'epsilon', or 'v_prediction'. Default: `epsilon`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
             [MeanSquaredError()].
         val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
@@ -86,7 +89,9 @@ def stable_diffusion_2(
 
     tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
+    noise_scheduler.prediction_type = prediction_type
     inference_noise_scheduler = DDIMScheduler.from_pretrained(model_name, subfolder='scheduler')
+    inference_noise_scheduler.prediction_type = prediction_type
 
     model = StableDiffusion(
         unet=unet,
@@ -95,6 +100,7 @@ def stable_diffusion_2(
         tokenizer=tokenizer,
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
+        prediction_type=prediction_type,
         train_metrics=train_metrics,
         val_metrics=val_metrics,
         val_guidance_scales=val_guidance_scales,

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -186,7 +186,7 @@ class StableDiffusion(ComposerModel):
         elif self.prediction_type == 'sample':
             targets = latents
         elif self.prediction_type == 'v_prediction':
-            targets = self.scheduler.get_velocity(latents, noise, timesteps)
+            targets = self.noise_scheduler.get_velocity(latents, noise, timesteps)
         else:
             raise ValueError(
                 f'prediction type must be one of sample, epsilon, or v_prediction. Got {self.prediction_type}')

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -203,7 +203,7 @@ class StableDiffusion(ComposerModel):
         if outputs is not None:
             return outputs
         # Get unet outputs
-        unet_out, noise, timesteps = self.forward(batch)
+        unet_out, targets, timesteps = self.forward(batch)
         # Sample images from the prompts in the batch
         prompts = batch[self.text_key]
         height, width = batch[self.image_key].shape[-2], batch[self.image_key].shape[-1]
@@ -216,7 +216,7 @@ class StableDiffusion(ComposerModel):
                                        seed=self.val_seed,
                                        progress_bar=False)
             generated_images[guidance_scale] = gen_images
-        return unet_out, noise, timesteps, generated_images
+        return unet_out, targets, timesteps, generated_images
 
     def get_metrics(self, is_train: bool = False):
         if is_train:

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -90,9 +90,9 @@ class StableDiffusion(ComposerModel):
         self.vae = vae
         self.noise_scheduler = noise_scheduler
         self.loss_fn = loss_fn
-        if prediction_type.lower() not in ['sample', 'epsilon', 'v_prediction']:
-            raise ValueError(f'prediction type must be one of sample, epsilon, or v_prediction. Got {prediction_type}')
         self.prediction_type = prediction_type.lower()
+        if self.prediction_type not in ['sample', 'epsilon', 'v_prediction']:
+            raise ValueError(f'prediction type must be one of sample, epsilon, or v_prediction. Got {prediction_type}')
         self.val_seed = val_seed
         self.image_key = image_key
         self.image_latents_key = image_latents_key


### PR DESCRIPTION
This PR adds the option to set different prediction types following the hugging face naming convention ('epsilon' for noise prediction 'sample' for sample prediction, and 'v_prediction' for velocity prediction). It was something of an oversight that these were not already included. 

[Test run with v-prediction](https://wandb.ai/mosaic-ml/stable-diffusion-256-subsets/runs/crx8ifgv)