### PR TITLE
Full SDXL Model

### DIFF
--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -65,12 +65,11 @@ class LogDiffusionImages(Callback):
             if model.sdxl:
                 if self.tokenized_prompts is None:
                     tokenized_prompts = [
-                        model.tokenizer(p, padding='max_length', truncation=True,
-                                        return_tensors='pt', input_ids=True)  # type: ignore
+                        model.tokenizer(p, padding='max_length', truncation=True, return_tensors='pt',
+                                        input_ids=True)  # type: ignore
                         for p in self.prompts
                     ]
-                    self.tokenized_prompts = [torch.cat(tokenized_prompts[0]), 
-                                              torch.cat(tokenized_prompts[1])]
+                    self.tokenized_prompts = [torch.cat(tokenized_prompts[0]), torch.cat(tokenized_prompts[1])]
                 self.tokenized_prompts[0] = self.tokenized_prompts[0].to(state.batch[self.text_key].device)
                 self.tokenized_prompts[1] = self.tokenized_prompts[1].to(state.batch[self.text_key].device)
             else:
@@ -81,7 +80,7 @@ class LogDiffusionImages(Callback):
                         for p in self.prompts
                     ]
                     self.tokenized_prompts = torch.cat(tokenized_prompts)
-                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)
+                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
 
             # Generate images
             with get_precision_context(state.precision):

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -62,24 +62,18 @@ class LogDiffusionImages(Callback):
             else:
                 model = state.model
 
+            if self.tokenized_prompts is None:
+                tokenized_prompts = [
+                    model.tokenizer(p, padding='max_length', truncation=True,
+                                    return_tensors='pt')['input_ids']  # type: ignore
+                    for p in self.prompts
+                ]
             if model.sdxl:
-                if self.tokenized_prompts is None:
-                    tokenized_prompts = [
-                        model.tokenizer(p, padding='max_length', truncation=True, return_tensors='pt',
-                                        input_ids=True)  # type: ignore
-                        for p in self.prompts
-                    ]
                 tokenized_prompts_1 = torch.cat([tp[0] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
                 tokenized_prompts_2 = torch.cat([tp[1] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
                 self.tokenized_prompts = [tokenized_prompts_1, tokenized_prompts_2]
             else:
-                if self.tokenized_prompts is None:
-                    tokenized_prompts = [
-                        model.tokenizer(p, padding='max_length', truncation=True,
-                                        return_tensors='pt')['input_ids']  # type: ignore
-                        for p in self.prompts
-                    ]
-                    self.tokenized_prompts = torch.cat(tokenized_prompts)
+                self.tokenized_prompts = torch.cat(tokenized_prompts)
                 self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
 
             # Generate images

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -63,18 +63,21 @@ class LogDiffusionImages(Callback):
                 model = state.model
 
             if self.tokenized_prompts is None:
-                tokenized_prompts = [
+                self.tokenized_prompts = [
                     model.tokenizer(p, padding='max_length', truncation=True,
                                     return_tensors='pt')['input_ids']  # type: ignore
                     for p in self.prompts
                 ]
+
             if model.sdxl:
-                tokenized_prompts_1 = torch.cat([tp[0] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
-                tokenized_prompts_2 = torch.cat([tp[1] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
+                tokenized_prompts_1 = torch.cat([tp[0] for tp in self.tokenized_prompts
+                                                ]).to(state.batch[self.text_key].device)
+                tokenized_prompts_2 = torch.cat([tp[1] for tp in self.tokenized_prompts
+                                                ]).to(state.batch[self.text_key].device)
                 self.tokenized_prompts = [tokenized_prompts_1, tokenized_prompts_2]
             else:
-                self.tokenized_prompts = torch.cat(tokenized_prompts)
-                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
+                self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
+                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)
 
             # Generate images
             with get_precision_context(state.precision):

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -69,9 +69,9 @@ class LogDiffusionImages(Callback):
                                         input_ids=True)  # type: ignore
                         for p in self.prompts
                     ]
-                    self.tokenized_prompts = [torch.cat(tokenized_prompts[0]), torch.cat(tokenized_prompts[1])]
-                self.tokenized_prompts[0] = self.tokenized_prompts[0].to(state.batch[self.text_key].device)
-                self.tokenized_prompts[1] = self.tokenized_prompts[1].to(state.batch[self.text_key].device)
+                tokenized_prompts_1 = torch.cat([tp[0] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
+                tokenized_prompts_2 = torch.cat([tp[1] for tp in tokenized_prompts]).to(state.batch[self.text_key].device)
+                self.tokenized_prompts = [tokenized_prompts_1, tokenized_prompts_2]
             else:
                 if self.tokenized_prompts is None:
                     tokenized_prompts = [

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -69,17 +69,11 @@ class LogDiffusionImages(Callback):
                     for p in self.prompts
                 ]
                 if model.sdxl:
-                    self.tokenized_prompts = [
-                        torch.cat([tp[0] for tp in self.tokenized_prompts]),
-                        torch.cat([tp[1] for tp in self.tokenized_prompts])
-                    ]
+                    self.tokenized_prompts = torch.stack([torch.cat(tp) for tp in self.tokenized_prompts
+                                                         ])  # [B, 2, max_length]
                 else:
                     self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
-            if model.sdxl:
-                self.tokenized_prompts[0] = self.tokenized_prompts[0].to(state.batch[self.text_key].device)
-                self.tokenized_prompts[1] = self.tokenized_prompts[1].to(state.batch[self.text_key].device)
-            else:
-                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
+            self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
 
             # Generate images
             with get_precision_context(state.precision):

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -68,16 +68,18 @@ class LogDiffusionImages(Callback):
                                     return_tensors='pt')['input_ids']  # type: ignore
                     for p in self.prompts
                 ]
-
+                if model.sdxl:
+                    self.tokenized_prompts = [
+                        torch.cat([tp[0] for tp in self.tokenized_prompts]),
+                        torch.cat([tp[1] for tp in self.tokenized_prompts])
+                    ]
+                else:
+                    self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
             if model.sdxl:
-                tokenized_prompts_1 = torch.cat([tp[0] for tp in self.tokenized_prompts
-                                                ]).to(state.batch[self.text_key].device)
-                tokenized_prompts_2 = torch.cat([tp[1] for tp in self.tokenized_prompts
-                                                ]).to(state.batch[self.text_key].device)
-                self.tokenized_prompts = [tokenized_prompts_1, tokenized_prompts_2]
+                self.tokenized_prompts[0] = self.tokenized_prompts[0].to(state.batch[self.text_key].device)
+                self.tokenized_prompts[1] = self.tokenized_prompts[1].to(state.batch[self.text_key].device)
             else:
-                self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
-                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)
+                self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
 
             # Generate images
             with get_precision_context(state.precision):

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -123,7 +123,8 @@ class StreamingImageCaptionDataset(StreamingDataset):
                                                 return_tensors='pt',
                                                 input_ids=True)
             tokenized_captions = [cap[0] for cap in tokenized_captions]
-            tokenized_caption = torch.stack(tokenized_captions)
+            tokenized_caption = torch.stack(tokenized_captions) 
+            print('stacked shape:', tokenized_caption.shape)
         else:
             tokenized_caption = self.tokenizer(
                 caption,

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -129,13 +129,12 @@ class StreamingImageCaptionDataset(StreamingDataset):
             if isinstance(caption, List) and self.caption_selection == 'random':
                 caption = random.sample(caption, k=1)[0]
 
-        max_length = None if self.sdxl else self.tokenizer.model_max_length
-        tokenized_caption = self.tokenizer(
-            caption,
-            padding='max_length',
-            max_length=max_length, 
-            truncation=True,
-            return_tensors='pt')['input_ids']
+        max_length = None if self.sdxl else self.tokenizer.model_max_length  # type: ignore
+        tokenized_caption = self.tokenizer(caption,
+                                           padding='max_length',
+                                           max_length=max_length,
+                                           truncation=True,
+                                           return_tensors='pt')['input_ids']
         if self.sdxl:
             tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenized_caption]
             tokenized_caption = torch.stack(tokenized_caption)

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -232,9 +232,6 @@ def build_streaming_image_caption_dataloader(
     transform = transforms.Compose(transform)
     assert isinstance(transform, Callable)
 
-    import streaming
-    streaming.base.util.clean_stale_shared_memory()
-
     dataset = StreamingImageCaptionDataset(
         streams=streams,
         tokenizer_name_or_path=tokenizer_name_or_path,

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -109,11 +109,11 @@ class StreamingImageCaptionDataset(StreamingDataset):
             # Microconditioning dropout as in Stability repo
             # https://github.com/Stability-AI/generative-models/blob/477d8b9a7730d9b2e92b326a770c0420d00308c9/sgm/modules/encoders/modules.py#L151-L160
             if torch.rand(1) < self.microcond_drop_prob:
-                out['cond_crops_coords_top_left'] = out['cond_crops_coords_top_left'] * 0.0
+                out['cond_crops_coords_top_left'] = out['cond_crops_coords_top_left'] * 0
             if torch.rand(1) < self.microcond_drop_prob:
-                out['cond_original_size'] = out['cond_original_size'] * 0.0
+                out['cond_original_size'] = out['cond_original_size'] * 0
             if torch.rand(1) < self.microcond_drop_prob:
-                out['cond_target_size'] = out['cond_target_size'] * 0.0
+                out['cond_target_size'] = out['cond_target_size'] * 0
         else:
             crop_top, crop_left, image_height, image_width = None, None, None, None
         if self.transform is not None:
@@ -231,6 +231,9 @@ def build_streaming_image_caption_dataloader(
             ]
     transform = transforms.Compose(transform)
     assert isinstance(transform, Callable)
+
+    import streaming
+    streaming.base.util.clean_stale_shared_memory()
 
     dataset = StreamingImageCaptionDataset(
         streams=streams,

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -181,7 +181,7 @@ def build_streaming_image_caption_dataloader(
         transform (Optional[Callable]): The transforms to apply to the image. Default: ``None``.
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_key (str): Key associated with the caption in the streaming dataset. Default: ``'caption'``.
-        rand_crop (bool): If True, randomly crop images. Otherwise, center crop. ``False``.
+        rand_crop (bool): If True, randomly crop images. Otherwise, center crop. Default: ``False``.
         streaming_kwargs (dict, optional): Additional arguments to pass to the ``StreamingDataset``. Default: ``None``.
         dataloader_kwargs (dict, optional): Additional arguments to pass to the ``DataLoader``. Default: ``None``.
     """

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -194,6 +194,7 @@ def build_streaming_image_caption_dataloader(
 
     # Infer SDXL from tokenizer path
     if tokenizer_name_or_path == 'stabilityai/stable-diffusion-xl-base-1.0':
+        print('Detected SDXL tokenizer, using SDXL crop transform and tokenizers.')
         sdxl = True
     else:
         sdxl = False

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -4,6 +4,7 @@
 """Streaming Image-Caption dataset."""
 
 import random
+import logging
 from io import BytesIO
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
@@ -16,6 +17,8 @@ from transformers import AutoTokenizer
 
 from diffusion.datasets.laion.transforms import LargestCenterSquare, RandomCropSquare, RandomCropSquareReturnTransform
 from diffusion.models.models import SDXLTokenizer
+
+log = logging.getLogger(__name__)
 
 # Disable PIL max image size limit
 Image.MAX_IMAGE_PIXELS = None
@@ -123,8 +126,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
                                                 return_tensors='pt',
                                                 input_ids=True)
             tokenized_captions = [cap[0] for cap in tokenized_captions]
-            tokenized_caption = torch.stack(tokenized_captions) 
-            print('stacked shape:', tokenized_caption.shape)
+            tokenized_caption = torch.stack(tokenized_captions)
         else:
             tokenized_caption = self.tokenizer(
                 caption,
@@ -195,7 +197,7 @@ def build_streaming_image_caption_dataloader(
 
     # Infer SDXL from tokenizer path
     if tokenizer_name_or_path == 'stabilityai/stable-diffusion-xl-base-1.0':
-        print('Detected SDXL tokenizer, using SDXL crop transform and tokenizers.')
+        log.info('Detected SDXL tokenizer, using SDXL crop transform and tokenizers.')
         sdxl = True
     else:
         sdxl = False

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -3,8 +3,8 @@
 
 """Streaming Image-Caption dataset."""
 
-import random
 import logging
+import random
 from io import BytesIO
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
@@ -164,7 +164,6 @@ def build_streaming_image_caption_dataloader(
     rand_crop: bool = False,
     streaming_kwargs: Optional[Dict] = None,
     dataloader_kwargs: Optional[Dict] = None,
-    
 ):
     """Builds a streaming LAION dataloader.
 
@@ -247,7 +246,6 @@ def build_streaming_image_caption_dataloader(
         sdxl=sdxl,
         **streaming_kwargs,
     )
-
 
     dataloader = DataLoader(
         dataset=dataset,

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -4,8 +4,8 @@
 """Transforms for the training and eval dataset."""
 
 import torchvision.transforms as transforms
-from torchvision.transforms.functional import crop
 from torchvision.transforms import RandomCrop
+from torchvision.transforms.functional import crop
 
 
 class LargestCenterSquare:

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -1,37 +1,11 @@
 # Copyright 2022 MosaicML Diffusion authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Transforms for the laion dataset."""
+"""Transforms for the training and eval dataset."""
 
-import numpy as np
 import torchvision.transforms as transforms
-from torchvision.transforms.functional import crop, get_dimensions
-
-
-def random_crop_params(img, output_size):
-    """Helper function to return the parameters for a random crop.
-
-    Args:
-        img (PIL Image or Tensor): Input image.
-        output_size (int): Size of output image.
-
-    Returns:
-        cropped_im (PIL Image or Tensor): Cropped square image of output_size.
-        c_top (int): Top crop coordinate.
-        c_left (int): Left crop coordinate.
-    """
-    _, image_height, image_width = get_dimensions(img)
-    if image_height == image_width:
-        c_left = 0
-        c_top = 0
-    elif image_height < image_width:
-        c_left = np.random.randint(0, image_width - output_size)
-        c_top = 0
-    else:
-        c_left = 0
-        c_top = np.random.randint(0, image_height - output_size)
-    cropped_im = crop(img, c_top, c_left, output_size, output_size)
-    return cropped_im, c_top, c_left
+from torchvision.transforms.functional import crop
+from torchvision.transforms import RandomCrop
 
 
 class LargestCenterSquare:
@@ -54,12 +28,14 @@ class RandomCropSquare:
 
     def __init__(self, size):
         self.size = size
+        self.random_crop = RandomCrop(size)
 
     def __call__(self, img):
         # First, resize the image such that the smallest side is self.size while preserving aspect ratio.
         img = transforms.functional.resize(img, self.size, antialias=True)
         # Then take a center crop to a square & return crop params.
-        img, _, _ = random_crop_params(img, self.size)
+        c_top, c_left, h, w = self.random_crop.get_params(img, (self.size, self.size))
+        img = crop(img, c_top, c_left, h, w)
         return img
 
 
@@ -68,11 +44,13 @@ class RandomCropSquareReturnTransform:
 
     def __init__(self, size):
         self.size = size
+        self.random_crop = RandomCrop(size)
 
     def __call__(self, img):
         # First, resize the image such that the smallest side is self.size while preserving aspect ratio.
         orig_w, orig_h = img.size
         img = transforms.functional.resize(img, self.size, antialias=True)
         # Then take a center crop to a square & return crop params.
-        img, c_top, c_left = random_crop_params(img, self.size)
+        c_top, c_left, h, w = self.random_crop.get_params(img, (self.size, self.size))
+        img = crop(img, c_top, c_left, h, w)
         return img, c_top, c_left, orig_h, orig_w

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -3,7 +3,35 @@
 
 """Transforms for the laion dataset."""
 
+import numpy as np
 import torchvision.transforms as transforms
+from torchvision.transforms.functional import crop, get_dimensions
+
+
+def random_crop_params(img, output_size):
+    """Helper function to return the parameters for a random crop.
+
+    Args:
+        img (PIL Image or Tensor): Input image.
+        output_size (int): Size of output image.
+
+    Returns:
+        cropped_im (PIL Image or Tensor): Cropped square image of output_size.
+        c_top (int): Top crop coordinate.
+        c_left (int): Left crop coordinate.
+    """
+    _, image_height, image_width = get_dimensions(img)
+    if image_height == image_width:
+        c_left = 0
+        c_top = 0
+    elif image_height < image_width:
+        c_left = np.random.randint(0, image_width - output_size)
+        c_top = 0
+    else:
+        c_left = 0
+        c_top = np.random.randint(0, image_height - output_size)
+    cropped_im = crop(img, c_top, c_left, output_size, output_size)
+    return cropped_im, c_top, c_left
 
 
 class LargestCenterSquare:
@@ -19,3 +47,32 @@ class LargestCenterSquare:
         # Then take a center crop to a square.
         img = self.center_crop(img)
         return img
+
+
+class RandomCropSquare:
+    """Randomly crop square of a PIL image."""
+
+    def __init__(self, size):
+        self.size = size
+
+    def __call__(self, img):
+        # First, resize the image such that the smallest side is self.size while preserving aspect ratio.
+        img = transforms.functional.resize(img, self.size, antialias=True)
+        # Then take a center crop to a square & return crop params.
+        img, _, _ = random_crop_params(img, self.size)
+        return img
+
+
+class RandomCropSquareReturnTransform:
+    """Randomly crop square of a PIL image and return the crop parameters."""
+
+    def __init__(self, size):
+        self.size = size
+
+    def __call__(self, img):
+        # First, resize the image such that the smallest side is self.size while preserving aspect ratio.
+        orig_w, orig_h = img.size
+        img = transforms.functional.resize(img, self.size, antialias=True)
+        # Then take a center crop to a square & return crop params.
+        img, c_top, c_left = random_crop_params(img, self.size)
+        return img, c_top, c_left, orig_h, orig_w

--- a/diffusion/models/layers.py
+++ b/diffusion/models/layers.py
@@ -1,0 +1,212 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpful layers and functions for UNet construction."""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+import xformers  # type: ignore
+
+
+def zero_module(module):
+    """Zero out the parameters of a module and return it."""
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+class ClampedAttnProcessor2_0:
+    """Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0)."""
+
+    def __init__(self, clip_val=6.0):
+        if not hasattr(F, 'scaled_dot_product_attention'):
+            raise ImportError('AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.')
+        self.clip_val = clip_val
+        print('initializing ClampedAttnProcessor2_0 with value %f!' % clip_val)
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        scale: float = 1.0,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+        else:
+            channel, height, width = None, None, None
+
+        batch_size, sequence_length, _ = (hidden_states.shape
+                                          if encoder_hidden_states is None else encoder_hidden_states.shape)
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states, scale=scale)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states, scale=scale)
+        value = attn.to_v(encoder_hidden_states, scale=scale)
+
+        query = query.clamp(min=-self.clip_val, max=self.clip_val)
+        key = key.clamp(min=-self.clip_val, max=self.clip_val)
+        value = value.clamp(min=-self.clip_val, max=self.clip_val)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        hidden_states = F.scaled_dot_product_attention(query,
+                                                       key,
+                                                       value,
+                                                       attn_mask=attention_mask,
+                                                       dropout_p=0.0,
+                                                       is_causal=False)
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states, scale=scale)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+class ClampedXFormersAttnProcessor:
+    """Processor for implementing memory efficient attention using xFormers.
+
+    Args:
+        attention_op (`Callable`, *optional*, defaults to `None`):
+            The base
+            [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
+            use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
+            operator.
+    """
+
+    def __init__(self, clip_val=6.0, attention_op=None):
+        self.attention_op = attention_op
+        self.clip_val = clip_val
+
+        print('initializing ClampedXFormersAttnProcessor with value %f - intentionally buggy version!' % clip_val)
+
+    def __call__(
+        self,
+        attn,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+        scale: float = 1.0,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+        else:
+            channel, height, width = None, None, None
+
+        batch_size, key_tokens, _ = (hidden_states.shape
+                                     if encoder_hidden_states is None else encoder_hidden_states.shape)
+
+        attention_mask = attn.prepare_attention_mask(attention_mask, key_tokens, batch_size)
+        if attention_mask is not None:
+            # expand our mask's singleton query_tokens dimension:
+            #   [batch*heads,            1, key_tokens] ->
+            #   [batch*heads, query_tokens, key_tokens]
+            # so that it can be added as a bias onto the attention scores that xformers computes:
+            #   [batch*heads, query_tokens, key_tokens]
+            # we do this explicitly because xformers doesn't broadcast the singleton dimension for us.
+            _, query_tokens, _ = hidden_states.shape
+            attention_mask = attention_mask.expand(-1, query_tokens, -1)
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states, scale=scale)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states, scale=scale)
+        value = attn.to_v(encoder_hidden_states, scale=scale)
+
+        query = query.clamp(min=-self.clip_val, max=self.clip_val)
+        key = query.clamp(min=-self.clip_val, max=self.clip_val)  # key.clamp(min=-self.clip_val, max=self.clip_val)
+        value = query.clamp(min=-self.clip_val, max=self.clip_val)  # value.clamp(min=-self.clip_val, max=self.clip_val)
+
+        query = attn.head_to_batch_dim(query).contiguous()
+        key = attn.head_to_batch_dim(key).contiguous()
+        value = attn.head_to_batch_dim(value).contiguous()
+
+        hidden_states = xformers.ops.memory_efficient_attention(query,
+                                                                key,
+                                                                value,
+                                                                attn_bias=attention_mask,
+                                                                op=self.attention_op,
+                                                                scale=attn.scale)
+        hidden_states = hidden_states.to(query.dtype)
+        hidden_states = attn.batch_to_head_dim(hidden_states)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states, scale=scale)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            assert channel
+            assert height
+            assert width
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states

--- a/diffusion/models/layers.py
+++ b/diffusion/models/layers.py
@@ -24,8 +24,11 @@ def zero_module(module):
 class ClippedAttnProcessor2_0:
     """Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
 
-    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py to
+    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py#L977 to
     allow clipping QKV values.
+
+    Args:
+        clip_val (float, defaults to 6.0): Amount to clip query, key, and value by.
     """
 
     def __init__(self, clip_val=6.0):
@@ -120,7 +123,7 @@ class ClippedAttnProcessor2_0:
 class ClippedXFormersAttnProcessor:
     """Processor for implementing memory efficient attention using xFormers.
 
-    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py to
+    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py#L888 to
     allow clipping QKV values.
 
     Args:
@@ -129,6 +132,7 @@ class ClippedXFormersAttnProcessor:
             [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
             use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
             operator.
+        clip_val (float, defaults to 6.0): Amount to clip query, key, and value by.
     """
 
     def __init__(self, clip_val=6.0, attention_op=None):

--- a/diffusion/models/layers.py
+++ b/diffusion/models/layers.py
@@ -18,7 +18,10 @@ def zero_module(module):
 
 
 class ClampedAttnProcessor2_0:
-    """Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0)."""
+    """Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
+
+    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py.
+    """
 
     def __init__(self, clip_val=6.0):
         if not hasattr(F, 'scaled_dot_product_attention'):
@@ -112,6 +115,8 @@ class ClampedAttnProcessor2_0:
 
 class ClampedXFormersAttnProcessor:
     """Processor for implementing memory efficient attention using xFormers.
+
+    Modified from https://github.com/huggingface/diffusers/blob/v0.21.0-release/src/diffusers/models/attention_processor.py.
 
     Args:
         attention_op (`Callable`, *optional*, defaults to `None`):

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -3,10 +3,10 @@
 
 """Constructors for diffusion models."""
 
+import logging
 from typing import List, Optional
 
 import torch
-import logging
 from composer.devices import DeviceGPU
 from diffusers import AutoencoderKL, DDIMScheduler, DDPMScheduler, EulerDiscreteScheduler, UNet2DConditionModel
 from torchmetrics import MeanSquaredError
@@ -132,7 +132,7 @@ def stable_diffusion_2(
             attn_processor = ClippedXFormersAttnProcessor(clip_val=clip_qkv)
         else:
             attn_processor = ClippedAttnProcessor2_0(clip_val=clip_qkv)
-        log.info('Using %s with clip_val %.1f'%(attn_processor.__class__, clip_qkv))
+        log.info('Using %s with clip_val %.1f' % (attn_processor.__class__, clip_qkv))
         model.unet.set_attn_processor(attn_processor)
 
     return model
@@ -256,7 +256,7 @@ def stable_diffusion_xl(
             attn_processor = ClippedXFormersAttnProcessor(clip_val=clip_qkv)
         else:
             attn_processor = ClippedAttnProcessor2_0(clip_val=clip_qkv)
-        log.info('Using %s with clip_val %.1f'%(attn_processor.__class__, clip_qkv))
+        log.info('Using %s with clip_val %.1f' % (attn_processor.__class__, clip_qkv))
         model.unet.set_attn_processor(attn_processor)
 
     return model
@@ -399,7 +399,7 @@ class SDXLTextEncoder(torch.nn.Module):
     @property
     def device(self):
         return self.text_encoder.device
-    
+
     def forward(self, tokenized_text):
         # first text encoder
         conditioning = self.text_encoder(tokenized_text[0], output_hidden_states=True).hidden_states[-2]

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -169,8 +169,12 @@ class SDXLTextEncoder:
         self.text_encoder.half()
         self.text_encoder_2.half()
 
-    def __call__(self, tokenized_output,
-                 tokenized_output_2):  # TODO need to pass second tokenized outputs and handle pooled output
+    def to_device(self, composer_device):
+        self.text_encoder = composer_device.module_to_device(self.text_encoder)
+        self.text_encoder_2 = composer_device.module_to_device(self.text_encoder_2)
+        self.device = self.text_encoder.device
+
+    def __call__(self, tokenized_output, tokenized_output_2):
         # first text encoder
         conditioning = self.text_encoder(tokenized_output, output_hidden_states=True).hidden_states[-2]
         # second text encoder
@@ -336,6 +340,9 @@ def stable_diffusion_xl(
         if is_xformers_installed:
             model.unet.enable_xformers_memory_efficient_attention()
             model.vae.enable_xformers_memory_efficient_attention()
+
+        # Manually set text encoders to device
+        text_encoder.to_device(DeviceGPU())
 
     if clip_qkv is not None:
         if is_xformers_installed:

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -226,6 +226,7 @@ def stable_diffusion_xl(
 
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
     inference_noise_scheduler = EulerDiscreteScheduler.from_pretrained(model_name, subfolder='scheduler')
+    inference_noise_scheduler.prediction_type = prediction_type
 
     model = StableDiffusion(
         unet=unet,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -143,11 +143,14 @@ class SDXLTextEncoder:
         model_name (str): Name of the model's text encoders to load. Defaults to 'stabilityai/stable-diffusion-xl-base-1.0'.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
     """
+
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', encode_latents_in_fp16=True):
         if encode_latents_in_fp16:
-            self.text_encoder = CLIPTextModel.from_pretrained(model_name, subfolder='text_encoder', torch_dtype=torch.float16)
-            self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(model_name, 
-                                                                              subfolder='text_encoder_2', 
+            self.text_encoder = CLIPTextModel.from_pretrained(model_name,
+                                                              subfolder='text_encoder',
+                                                              torch_dtype=torch.float16)
+            self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(model_name,
+                                                                              subfolder='text_encoder_2',
                                                                               torch_dtype=torch.float16)
         else:
             self.text_encoder = CLIPTextModel.from_pretrained(model_name, subfolder='text_encoder')
@@ -166,7 +169,8 @@ class SDXLTextEncoder:
         self.text_encoder.half()
         self.text_encoder_2.half()
 
-    def __call__(self, tokenized_output, tokenized_output_2): # TODO need to pass second tokenized outputs and handle pooled output
+    def __call__(self, tokenized_output,
+                 tokenized_output_2):  # TODO need to pass second tokenized outputs and handle pooled output
         # first text encoder
         conditioning = self.text_encoder(tokenized_output, output_hidden_states=True).hidden_states[-2]
         # second text encoder
@@ -193,6 +197,7 @@ class SDXLTokenizer:
     Args:
         model_name (str): Name of the model's text encoders to load. Defaults to 'stabilityai/stable-diffusion-xl-base-1.0'.
     """
+
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0'):
         self.tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer_2')
@@ -299,7 +304,7 @@ def stable_diffusion_xl(
     else:
         try:
             vae = AutoencoderKL.from_pretrained(vae_model_name, subfolder='vae')
-        except: #  for handling SDXL vae fp16 fixed checkpoint
+        except:  #  for handling SDXL vae fp16 fixed checkpoint
             vae = AutoencoderKL.from_pretrained(vae_model_name)
 
     tokenizer = SDXLTokenizer(model_name)

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -179,7 +179,8 @@ def stable_diffusion_xl(
         precomputed_latents (bool): Whether to use precomputed latents. Defaults to False.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
         fsdp (bool): Whether to use FSDP. Defaults to True.
-        clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to 6.0.
+        clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to 6.0. Improves stability
+            of training.
     """
     if train_metrics is None:
         train_metrics = [MeanSquaredError()]

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -199,7 +199,7 @@ def stable_diffusion_xl(
             metric.requires_grad_(False)
 
     if pretrained:
-        unet = UNet2DConditionModel.from_pretrained(model_name, subfolder='unet')
+        unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
     else:
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
         unet = UNet2DConditionModel(**config[0])

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -395,7 +395,7 @@ class SDXLTextEncoder(torch.nn.Module):
         self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(model_name,
                                                                           subfolder='text_encoder_2',
                                                                           torch_dtype=torch_dtype)
-        
+
     @property
     def device(self):
         return self.text_encoder.device

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -427,17 +427,19 @@ class SDXLTokenizer:
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer_2')
 
     def __call__(self, prompt, padding, truncation, return_tensors, max_length=None):
-        tokenized_output = self.tokenizer(prompt,
-                                          padding=padding,
-                                          max_length=self.tokenizer.model_max_length if max_length is None else max_length,
-                                          truncation=truncation,
-                                          return_tensors=return_tensors)
-        tokenized_output_2 = self.tokenizer_2(prompt,
-                                              padding=padding,
-                                              max_length=self.tokenizer_2.model_max_length  if max_length is None else max_length,
-                                              truncation=truncation,
-                                              return_tensors=return_tensors)
-        
+        tokenized_output = self.tokenizer(
+            prompt,
+            padding=padding,
+            max_length=self.tokenizer.model_max_length if max_length is None else max_length,
+            truncation=truncation,
+            return_tensors=return_tensors)
+        tokenized_output_2 = self.tokenizer_2(
+            prompt,
+            padding=padding,
+            max_length=self.tokenizer_2.model_max_length if max_length is None else max_length,
+            truncation=truncation,
+            return_tensors=return_tensors)
+
         # Add second tokenizer output to first tokenizer
         for key in tokenized_output.keys():
             tokenized_output[key] = [tokenized_output[key], tokenized_output_2[key]]

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -170,8 +170,6 @@ class StableDiffusion(ComposerModel):
         else:
             inputs, conditioning = batch[self.image_key], batch[self.text_key]
             if self.sdxl:
-                # TODO check this
-                print('batch of tokens shape:', conditioning.shape)
                 conditioning, conditioning_2 = conditioning[:,0,:], conditioning[:,1,:] # [B, 2, 77]
             else:
                 conditioning_2 = None

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -413,7 +413,7 @@ class StableDiffusion(ComposerModel):
         # negative prompt is given in place of the unconditional input in classifier free guidance
         pooled_embeddings = None
         if do_classifier_free_guidance:
-            if not negative_prompt and not tokenized_negative_prompts and zero_out_negative_prompt:
+            if not negative_prompt and not tokenized_negative_prompts and not negative_prompt_embeds and zero_out_negative_prompt:
                 # Negative prompt is empty and we want to zero it out
                 unconditional_embeddings = torch.zeros_like(text_embeddings)
                 pooled_unconditional_embeddings = torch.zeros_like(pooled_text_embeddings) if self.sdxl else None

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -447,12 +447,8 @@ class StableDiffusion(ComposerModel):
                 crop_params = [0., 0.]
             if not size_params:
                 size_params = [width, height]
-            cond_original_size = torch.tensor([[width, height]]).repeat(pooled_embeddings.shape[0],
-                                                                        1).to(device).float()
-            cond_crops_coords_top_left = torch.tensor([crop_params]).repeat(pooled_embeddings.shape[0],
-                                                                            1).to(device).float()
-            cond_target_size = torch.tensor([size_params]).repeat(pooled_embeddings.shape[0], 1).to(device).float()
-            add_time_ids = torch.cat([cond_original_size, cond_crops_coords_top_left, cond_target_size], dim=1).float()
+            add_time_ids = torch.tensor([[width, height, *crop_params, *size_params]], dtype=torch.float, device=device)
+            add_time_ids = add_time_ids.repeat(pooled_embeddings.shape[0], 1)
             add_text_embeds = pooled_embeddings
 
             added_cond_kwargs = {'text_embeds': add_text_embeds, 'time_ids': add_time_ids}

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -171,7 +171,7 @@ class StableDiffusion(ComposerModel):
             inputs, conditioning = batch[self.image_key], batch[self.text_key]
             if self.sdxl:
                 # If SDXL, separate the conditioning ([B, 2, 77]) from each tokenizer
-                conditioning, conditioning_2 = conditioning[:,0,:], conditioning[:,1,:]
+                conditioning, conditioning_2 = conditioning[:, 0, :], conditioning[:, 1, :]
                 conditioning_2 = conditioning_2.view(-1, conditioning_2.shape[-1])
 
             conditioning = conditioning.view(-1, conditioning.shape[-1])

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -493,7 +493,8 @@ class StableDiffusion(ComposerModel):
                                                    max_length=max_length,
                                                    truncation=True,
                                                    return_tensors='pt').input_ids
-                tokenized_prompts = torch.stack([tokenized_prompts[0], tokenized_prompts[1]], dim=1)
+                if self.sdxl:
+                    tokenized_prompts = torch.stack([tokenized_prompts[0], tokenized_prompts[1]], dim=1)
             if self.sdxl:
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
                     [tokenized_prompts[:, 0, :].to(device), tokenized_prompts[:, 1, :].to(device)])  # type: ignore

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -350,9 +350,9 @@ class StableDiffusion(ComposerModel):
                 image generation away from. Ignored when not using guidance
                 (i.e., ignored if guidance_scale is less than 1).
                 Must be the same length as list of prompts. Default: `None`.
-            tokenized_prompts (torch.LongTensor or List[torch.LongTensor]): Optionally pass
-                pre-tokenized prompts instead of string prompts. If SDXL, this will be a list
-                of two pre-tokenized prompts. Default: `None`.
+            tokenized_prompts (torch.LongTensor): Optionally pass pre-tokenized prompts instead
+                of string prompts. If SDXL, this will be a tensor of size [B, 2, max_length],
+                otherwise will be of shape [B, max_length]. Default: `None`.
             tokenized_negative_prompts (torch.LongTensor): Optionally pass pre-tokenized negative
                 prompts instead of string prompts. Default: `None`.
             prompt_embeds (torch.FloatTensor): Optionally pass pre-tokenized prompts instead
@@ -496,7 +496,7 @@ class StableDiffusion(ComposerModel):
                                                    return_tensors='pt').input_ids
             if self.sdxl:
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
-                    [tokenized_prompts[0].to(device), tokenized_prompts[1].to(device)])  # type: ignore
+                    [tokenized_prompts[:, 0, :].to(device), tokenized_prompts[:, 1, :].to(device)])  # type: ignore
             else:
                 text_embeddings = self.text_encoder(tokenized_prompts.to(device))[0]  # type: ignore
         else:

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -494,6 +494,7 @@ class StableDiffusion(ComposerModel):
                                                    max_length=max_length,
                                                    truncation=True,
                                                    return_tensors='pt').input_ids
+                tokenized_prompts = torch.stack([tokenized_prompts[0], tokenized_prompts[1]], dim=1)
             if self.sdxl:
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
                     [tokenized_prompts[:, 0, :].to(device), tokenized_prompts[:, 1, :].to(device)])  # type: ignore

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -491,22 +491,17 @@ class StableDiffusion(ComposerModel):
         device = self.text_encoder.device
         pooled_text_embeddings = None
         if prompt_embeds is None:
+            max_length = None if self.sdxl else self.tokenizer.model_max_length
+            if tokenized_prompts is None:
+                tokenized_prompts = self.tokenizer(prompt,
+                                                   padding='max_length',
+                                                   max_length=max_length,
+                                                   truncation=True,
+                                                   return_tensors='pt').input_ids
             if self.sdxl:
-                if tokenized_prompts is None:
-                    tokenized_prompts = self.tokenizer(prompt,
-                                                       padding='max_length',
-                                                       truncation=True,
-                                                       return_tensors='pt',
-                                                       input_ids=True)
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
                     [tokenized_prompts[0].to(device), tokenized_prompts[1].to(device)])  # type: ignore
             else:
-                if tokenized_prompts is None:
-                    tokenized_prompts = self.tokenizer(prompt,
-                                                       padding='max_length',
-                                                       max_length=self.tokenizer.model_max_length,
-                                                       truncation=True,
-                                                       return_tensors='pt').input_ids
                 text_embeddings = self.text_encoder(tokenized_prompts.to(device))[0]  # type: ignore
         else:
             if self.sdxl:

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -193,7 +193,7 @@ class StableDiffusion(ComposerModel):
             if self.sdxl:
                 assert conditioning_2 is not None
                 conditioning_2 = conditioning_2.view(-1, conditioning_2.shape[-1])
-                conditioning, pooled_conditioning = self.text_encoder(conditioning, conditioning_2)
+                conditioning, pooled_conditioning = self.text_encoder([conditioning, conditioning_2])
             else:
                 conditioning = self.text_encoder(conditioning)[0]
 
@@ -219,7 +219,6 @@ class StableDiffusion(ComposerModel):
         added_cond_kwargs = {}
         # if using SDXL, prepare added time ids & embeddings
         if self.sdxl:
-            # TODO double check cond_crops_coords_top_left calc in transforms.py
             add_time_ids = torch.cat(
                 [batch['cond_original_size'], batch['cond_crops_coords_top_left'], batch['cond_target_size']], dim=1)
             add_text_embeds = pooled_conditioning
@@ -312,7 +311,7 @@ class StableDiffusion(ComposerModel):
             if self.sdxl:
                 # Decode captions with first tokenizer
                 captions = [
-                    self.tokenizer.tokenizer.decode(caption, skip_special_tokens=True)
+                    self.tokenizer.tokenizer.decode(caption[0], skip_special_tokens=True)
                     for caption in batch[self.text_key]
                 ]
             else:
@@ -505,7 +504,7 @@ class StableDiffusion(ComposerModel):
                                                        input_ids=True)
                 # TODO implement zero-ing out empty prompts!
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
-                    tokenized_prompts[0].to(device), tokenized_prompts[1].to(device))  # type: ignore
+                    [tokenized_prompts[0].to(device), tokenized_prompts[1].to(device)])  # type: ignore
             else:
                 if tokenized_prompts is None:
                     tokenized_prompts = self.tokenizer(prompt,

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -171,7 +171,8 @@ class StableDiffusion(ComposerModel):
             inputs, conditioning = batch[self.image_key], batch[self.text_key]
             if self.sdxl:
                 # TODO check this
-                conditioning, conditioning_2 = conditioning[0], conditioning[1]
+                print('batch of tokens shape:', conditioning.shape)
+                conditioning, conditioning_2 = conditioning[:,0,:], conditioning[:,1,:] # [B, 2, 77]
             else:
                 conditioning_2 = None
             conditioning = conditioning.view(-1, conditioning.shape[-1])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'mosaicml-streaming>=0.4.0,<1.0',
     'hydra-core>=1.2',
     'hydra-colorlog>=1.1.0',
-    'diffusers[torch]==0.19.3',
+    'diffusers[torch]==0.21.0',
     'transformers[torch]==4.31.0',
     'wandb==0.15.4',
     'xformers==0.0.21',


### PR DESCRIPTION
This PR contains the full implementation of Stable Diffusion XL (SDXL). SDXL uses two text encoders/tokenizers and also takes crop & size parameters from the dataloader as conditioning - a majority of the changes here are for supporting that. 

**A high-level description of the changes for each file:**

`diffusion/datasets/image_caption.py`
- Added `rand_crop` flag to choose between `LargestCenterSquare` & `RandomCropSquare` - previously only center cropping was supported. This is relevant to SD2 if one might want to train with random cropping, but doesn't apply to SDXL
- Infer whether or not we're doing SDXL training by the `tokenizer_name_or_path`
- Use `RandomCropSquareReturnTransform` for SDXL, which returns the cropping parameters used as well as original image size (for training SDXL with micro-conditioning) and return micro-conditioning as part of the training batch 
- Add option to do micro-conditioning dropout (by setting `microcond_drop_prob` flag). This is not discussed in the SDXL paper but is reflected in [Stability AI's implementation](https://github.com/Stability-AI/generative-models/blob/477d8b9a7730d9b2e92b326a770c0420d00308c9/sgm/modules/encoders/modules.py#L151-L160)
- Small changes necessary for using `SDXLTokenizer`

`diffusion/datasets/laion/transforms.py`
- Implementation of random cropping
- `RandomCropSquare` (does random crop only) and `RandomCropSquareReturnTransform` (does random crop and returns crop params)

`diffusion/models/layers.py`
- Contains attention processor classes for QKV clipping
- Contains `zero_module` function used in SDXL init

`diffusion/models/models.py`
- Add option to do QKV clipping for both SD2 and SDXL (`clip_qkv` argument)
- For SDXL, instantiate `SDXLTokenizer` and `SDXLTextEncoder` which contain the two tokenizers/text encoders but mostly can be used as if they are one tokenizer/text encoder
- For SDXL, do zero init trick

`diffusion/models/stable_diffusion.py`
- Pass `sdxl` flag to StableDiffusion to indicate if we are training an SDXL model
- Set appropriate `latent_scale` for SD2 vs. SDXL
- Extract `pooled_conditioning` from SDXL text encoder, which is used in micro-conditioning
- Construct micro-conditioning dict and pass it to the UNet forward call
- In StableDiffusion.generate(...), allow user to pass `crop_params` and `size_params` for SDXL micro-conditioning, otherwise set them to reasonable default values
- In StableDiffusion.generate(...), new flag called `zero_out_negative_prompt` that zero's out the negative prompt if it is empty (rather than tokenizing and encoding the empty string). This was added to match the behavior of the diffusers [StableDiffusionXLPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl) and in general this just seems like a good thing to do. Note: I set the default value to be `True`, so this means previously made generations (e.g. with SD2) will look different despite using the same prompt/seed. Obviously can set it to `False` to match previous results.

`diffusion/callbacks/log_diffusion_images.py`
- Edits to support multiple tokenizers

`setup.py`
- Pin diffusers version to 0.21.0 - this is necessary because attention processor implementations are tied to this version

**There are a few remaining things I'd like to add, but this is already a big enough PR. I will add the following once this one is merged in:**
- Zero-ing out dropped captions rather than tokenizing/encoding the empty string during training (this can apply to SD2 training as well)
- Adding a `CenterCropSquareReturnTransform` transformation that can be used for COCO eval. Currently with SDXL training we do random crop for the eval dataset as well
- Allow user to pass different prompts to the different text encoders in SDXL inference