### PR TITLE
Add rescaled classifier free guidance and offset noise

### DIFF
--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -26,8 +26,8 @@ class LogDiffusionImages(Callback):
             A larger guidance scale generates images that are more aligned to
             the text prompt, usually at the expense of lower image quality.
             Default: ``0.0``.
-        rescale_guidance (bool, optional): Whether to use rescaled classifier free guidance or not. Default: ``False``.
-        rescaled_guidance_scale (float, optional): Rescaled guidance scale. Default: ``0.7``.
+        rescaled_guidance (float, optional): Rescaled guidance scale. If not specified, rescaled guidance
+            will not be used. Default: ``None``.
         text_key (str, optional): Key in the batch to use for text prompts. Default: ``'captions'``.
         tokenized_prompts (torch.LongTensor or List[torch.LongTensor], optional): Batch of pre-tokenized prompts
             to use for evaluation. If SDXL, this will be a list of two pre-tokenized prompts Default: ``None``.
@@ -41,8 +41,7 @@ class LogDiffusionImages(Callback):
                  size: Optional[int] = 256,
                  num_inference_steps=50,
                  guidance_scale: Optional[float] = 0.0,
-                 rescale_guidance: Optional[bool] = False,
-                 rescaled_guidance_scale: Optional[float] = 0.7,
+                 rescaled_guidance: Optional[float] = None,
                  text_key: Optional[str] = 'captions',
                  tokenized_prompts: Optional[torch.LongTensor] = None,
                  seed: Optional[int] = 1138,
@@ -51,8 +50,7 @@ class LogDiffusionImages(Callback):
         self.size = size
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale
-        self.rescale_guidance = rescale_guidance
-        self.rescaled_guidance_scale = rescaled_guidance_scale
+        self.rescaled_guidance = rescaled_guidance
         self.text_key = text_key
         self.seed = seed
         self.tokenized_prompts = tokenized_prompts
@@ -88,8 +86,7 @@ class LogDiffusionImages(Callback):
                     height=self.size,
                     width=self.size,
                     guidance_scale=self.guidance_scale,
-                    rescale_guidance=self.rescale_guidance,
-                    rescaled_guidance_scale=self.rescaled_guidance_scale,
+                    rescaled_guidance=self.rescaled_guidance,
                     progress_bar=False,
                     num_inference_steps=self.num_inference_steps,
                     seed=self.seed)

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -26,6 +26,8 @@ class LogDiffusionImages(Callback):
             A larger guidance scale generates images that are more aligned to
             the text prompt, usually at the expense of lower image quality.
             Default: ``0.0``.
+        rescale_guidance (bool, optional): Whether to use rescaled classifier free guidance or not. Default: ``False``.
+        rescaled_guidance_scale (float, optional): Rescaled guidance scale. Default: ``0.7``.
         text_key (str, optional): Key in the batch to use for text prompts. Default: ``'captions'``.
         tokenized_prompts (torch.LongTensor or List[torch.LongTensor], optional): Batch of pre-tokenized prompts
             to use for evaluation. If SDXL, this will be a list of two pre-tokenized prompts Default: ``None``.
@@ -39,6 +41,8 @@ class LogDiffusionImages(Callback):
                  size: Optional[int] = 256,
                  num_inference_steps=50,
                  guidance_scale: Optional[float] = 0.0,
+                 rescale_guidance: Optional[bool] = False,
+                 rescaled_guidance_scale: Optional[float] = 0.7,
                  text_key: Optional[str] = 'captions',
                  tokenized_prompts: Optional[torch.LongTensor] = None,
                  seed: Optional[int] = 1138,
@@ -47,6 +51,8 @@ class LogDiffusionImages(Callback):
         self.size = size
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale
+        self.rescale_guidance = rescale_guidance
+        self.rescaled_guidance_scale = rescaled_guidance_scale
         self.text_key = text_key
         self.seed = seed
         self.tokenized_prompts = tokenized_prompts
@@ -82,6 +88,8 @@ class LogDiffusionImages(Callback):
                     height=self.size,
                     width=self.size,
                     guidance_scale=self.guidance_scale,
+                    rescale_guidance=self.rescale_guidance,
+                    rescaled_guidance_scale=self.rescaled_guidance_scale,
                     progress_bar=False,
                     num_inference_steps=self.num_inference_steps,
                     seed=self.seed)

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -33,8 +33,7 @@ def stable_diffusion_2(
     model_name: str = 'stabilityai/stable-diffusion-2-base',
     pretrained: bool = True,
     prediction_type: str = 'epsilon',
-    offset_noise: bool = False,
-    offset_noise_scale: float = 0.1,
+    offset_noise: Optional[float] = None,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     val_guidance_scales: Optional[List] = None,
@@ -65,8 +64,8 @@ def stable_diffusion_2(
         loss_bins (list, optional): List of tuples of (min, max) values to use for loss binning. If None, defaults to
             [(0, 1)].
         precomputed_latents (bool): Whether to use precomputed latents. Defaults to False.
-        offset_noise (bool): Whether or not to use offset noise. Defaults to False.
-        offset_noise_scale (float): The scale of the offset noise. Default `0.1`.
+        offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
+            be used. Default `None`.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
         fsdp (bool): Whether to use FSDP. Defaults to True.
         clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to None.
@@ -117,7 +116,6 @@ def stable_diffusion_2(
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
         offset_noise=offset_noise,
-        offset_noise_scale=offset_noise_scale,
         train_metrics=train_metrics,
         val_metrics=val_metrics,
         val_guidance_scales=val_guidance_scales,
@@ -150,8 +148,7 @@ def stable_diffusion_xl(
     vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
     pretrained: bool = True,
     prediction_type: str = 'epsilon',
-    offset_noise: bool = False,
-    offset_noise_scale: float = 0.1,
+    offset_noise: Optional[float] = None,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     val_guidance_scales: Optional[List] = None,
@@ -178,8 +175,8 @@ def stable_diffusion_xl(
         pretrained (bool): Whether to load pretrained weights. Defaults to True.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
-        offset_noise (bool): Whether or not to use offset noise. Defaults to False.
-        offset_noise_scale (float): The scale of the offset noise. Default `0.1`.
+        offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
+            be used. Default `None`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
             [MeanSquaredError()].
         val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
@@ -255,7 +252,6 @@ def stable_diffusion_xl(
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
         offset_noise=offset_noise,
-        offset_noise_scale=offset_noise_scale,
         train_metrics=train_metrics,
         val_metrics=val_metrics,
         val_guidance_scales=val_guidance_scales,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -33,6 +33,8 @@ def stable_diffusion_2(
     model_name: str = 'stabilityai/stable-diffusion-2-base',
     pretrained: bool = True,
     prediction_type: str = 'epsilon',
+    offset_noise: bool = False,
+    offset_noise_scale: float = 0.1,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     val_guidance_scales: Optional[List] = None,
@@ -63,6 +65,8 @@ def stable_diffusion_2(
         loss_bins (list, optional): List of tuples of (min, max) values to use for loss binning. If None, defaults to
             [(0, 1)].
         precomputed_latents (bool): Whether to use precomputed latents. Defaults to False.
+        offset_noise (bool): Whether or not to use offset noise. Defaults to False.
+        offset_noise_scale (float): The scale of the offset noise. Default `0.1`.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
         fsdp (bool): Whether to use FSDP. Defaults to True.
         clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to None.
@@ -112,6 +116,8 @@ def stable_diffusion_2(
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
+        offset_noise=offset_noise,
+        offset_noise_scale=offset_noise_scale,
         train_metrics=train_metrics,
         val_metrics=val_metrics,
         val_guidance_scales=val_guidance_scales,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -235,8 +235,16 @@ def stable_diffusion_xl(
     text_encoder = SDXLTextEncoder(model_name, encode_latents_in_fp16)
 
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
-    inference_noise_scheduler = EulerDiscreteScheduler.from_pretrained(model_name, subfolder='scheduler')
-    inference_noise_scheduler.prediction_type = prediction_type
+    inference_noise_scheduler = EulerDiscreteScheduler(num_train_timesteps=1000,
+                                                       beta_start=0.00085,
+                                                       beta_end=0.012,
+                                                       beta_schedule='scaled_linear',
+                                                       trained_betas=None,
+                                                       prediction_type=prediction_type,
+                                                       interpolation_type='linear',
+                                                       use_karras_sigmas=False,
+                                                       timestep_spacing='leading',
+                                                       steps_offset=1)
 
     model = StableDiffusion(
         unet=unet,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -150,6 +150,8 @@ def stable_diffusion_xl(
     vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
     pretrained: bool = True,
     prediction_type: str = 'epsilon',
+    offset_noise: bool = False,
+    offset_noise_scale: float = 0.1,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     val_guidance_scales: Optional[List] = None,
@@ -176,6 +178,8 @@ def stable_diffusion_xl(
         pretrained (bool): Whether to load pretrained weights. Defaults to True.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
+        offset_noise (bool): Whether or not to use offset noise. Defaults to False.
+        offset_noise_scale (float): The scale of the offset noise. Default `0.1`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
             [MeanSquaredError()].
         val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
@@ -242,6 +246,8 @@ def stable_diffusion_xl(
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
+        offset_noise=offset_noise,
+        offset_noise_scale=offset_noise_scale,
         train_metrics=train_metrics,
         val_metrics=val_metrics,
         val_guidance_scales=val_guidance_scales,

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -39,8 +39,8 @@ class StableDiffusion(ComposerModel):
         loss_fn (torch.nn.Module): torch loss function. Default: `F.mse_loss`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
-        offset_noise (bool): Whether or not to use offset noise. Default `False`.
-        offset_noise_scale (float): The scale of the offset noise. Default `0.1`.
+        offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
+            be used. Default `None`.
         train_metrics (list): List of torchmetrics to calculate during training.
             Default: `None`.
         val_metrics (list): List of torchmetrics to calculate during validation.
@@ -76,8 +76,7 @@ class StableDiffusion(ComposerModel):
                  inference_noise_scheduler,
                  loss_fn=F.mse_loss,
                  prediction_type: str = 'epsilon',
-                 offset_noise: bool = False,
-                 offset_noise_scale: float = 0.1,
+                 offset_noise: Optional[float] = None,
                  train_metrics: Optional[List] = None,
                  val_metrics: Optional[List] = None,
                  val_seed: int = 1138,
@@ -100,7 +99,6 @@ class StableDiffusion(ComposerModel):
         if self.prediction_type not in ['sample', 'epsilon', 'v_prediction']:
             raise ValueError(f'prediction type must be one of sample, epsilon, or v_prediction. Got {prediction_type}')
         self.offset_noise = offset_noise
-        self.offset_noise_scale = offset_noise_scale
         self.val_seed = val_seed
         self.image_key = image_key
         self.image_latents_key = image_latents_key
@@ -206,9 +204,9 @@ class StableDiffusion(ComposerModel):
         timesteps = torch.randint(0, len(self.noise_scheduler), (latents.shape[0],), device=latents.device)
         # Add noise to the inputs (forward diffusion)
         noise = torch.randn_like(latents)
-        if self.offset_noise:
+        if self.offset_noise is not None:
             offset_noise = torch.randn(latents.shape[0], latents.shape[1], 1, 1, device=noise.device)
-            noise += self.offset_noise_scale * offset_noise
+            noise += self.offset_noise * offset_noise
         noised_latents = self.noise_scheduler.add_noise(latents, noise, timesteps)
         # Generate the targets
         if self.prediction_type == 'epsilon':
@@ -341,8 +339,7 @@ class StableDiffusion(ComposerModel):
         width: Optional[int] = None,
         num_inference_steps: Optional[int] = 50,
         guidance_scale: Optional[float] = 3.0,
-        rescale_guidance: bool = False,
-        rescaled_guidance_scale: float = 0.7,
+        rescaled_guidance: Optional[float] = None,
         num_images_per_prompt: Optional[int] = 1,
         seed: Optional[int] = None,
         progress_bar: Optional[bool] = True,
@@ -385,8 +382,8 @@ class StableDiffusion(ComposerModel):
                 Higher guidance scale encourages to generate images that are closely linked
                 to the text prompt, usually at the expense of lower image quality.
                 Default: `3.0`.
-            rescale_guidance (bool): Whether to use rescaled classifier free guidance or not. Default: `False`.
-            rescaled_guidance_scale (float): Rescaled guidance scale. Default: `0.7`.
+            rescaled_guidance (float, optional): Rescaled guidance scale. If not specified, rescaled guidance will
+                not be used. Default: `None`.
             num_images_per_prompt (int): The number of images to generate per prompt.
                  Default: `1`.
             progress_bar (bool): Whether to use the tqdm progress bar during generation.
@@ -484,11 +481,11 @@ class StableDiffusion(ComposerModel):
                 pred_uncond, pred_text = pred.chunk(2)
                 pred = pred_uncond + guidance_scale * (pred_text - pred_uncond)
                 # Optionally rescale the classifer free guidance
-                if rescale_guidance:
+                if rescaled_guidance is not None:
                     std_pos = torch.std(pred_text, dim=(1, 2, 3), keepdim=True)
                     std_cfg = torch.std(pred, dim=(1, 2, 3), keepdim=True)
                     pred_rescaled = pred * (std_pos / std_cfg)
-                    pred = pred_rescaled * rescaled_guidance_scale + pred * (1 - rescaled_guidance_scale)
+                    pred = pred_rescaled * rescaled_guidance + pred * (1 - rescaled_guidance)
             # compute the previous noisy sample x_t -> x_t-1
             latents = self.inference_scheduler.step(pred, t, latents, generator=rng_generator).prev_sample
 


### PR DESCRIPTION
This PR adds two simple tricks that are claimed to improve image quality.

Trick 1: Rescaled classifier free guidance (see sec. 3.4 [here](https://arxiv.org/abs/2305.08891))
- A simple rescaling of the latents during classifier free guidance to help ameliorate the image over exposure problem.

Trick 2: Offset noise (see [here](https://www.crosslabs.org/blog/diffusion-with-offset-noise))
- A trick for using to fine tune models such that they can generate lighter/darker images. Adds a slight offset to the noise during training.