### PR TITLE
Fix mixed precision torch compile bug

### DIFF
--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -152,8 +152,8 @@ class StableDiffusion(ComposerModel):
         self.text_encoder.requires_grad_(False)
         self.vae.requires_grad_(False)
         if self.encode_latents_in_fp16:
-            self.text_encoder.half()
-            self.vae.half()
+            self.text_encoder = self.text_encoder.half()
+            self.vae = self.vae.half()
         if fsdp:
             # only wrap models we are training
             self.text_encoder._fsdp_wrap = False


### PR DESCRIPTION
This is solves the bug that torch compile encountered. It didn't know the module was in fp16 until it hit weights in the backward pass because it does not know that .half() has side-effects. Making the program adhere to a more functional paradigm completely solves this bug (by invalidating the dtype cache of the nn Module).