### PR TITLE
Zero dropped captions

### DIFF
--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -43,7 +43,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_key (str): Key associated with the caption in the streaming dataset. Default: ``'caption'``.
         sdxl (bool): Whether or not we're training SDXL. Default: `False`.
-        zero_dropped_captions (bool): If True, zero out text embeddings for dropped captions. Default: ``True``.
+        zero_dropped_captions (bool): If True, zero out text embeddings for dropped captions. Default: ``False``.
 
         **streaming_kwargs: Additional arguments to pass in the construction of the StreamingDataloader
     """
@@ -62,7 +62,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         image_key: str = 'image',
         caption_key: str = 'caption',
         sdxl: bool = False,
-        zero_dropped_captions: bool = True,
+        zero_dropped_captions: bool = False,
         **streaming_kwargs,
     ) -> None:
 

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -197,9 +197,10 @@ class StableDiffusion(ComposerModel):
             latents *= self.latent_scale
 
         # Zero dropped captions if needed
-        conditioning *= batch['drop_caption_mask'].view(-1, 1, 1)
-        if pooled_conditioning is not None:
-            pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
+        if 'drop_caption_mask' in batch.keys():
+            conditioning *= batch['drop_caption_mask'].view(-1, 1, 1)
+            if pooled_conditioning is not None:
+                pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
 
         # Sample the diffusion timesteps
         timesteps = torch.randint(0, len(self.noise_scheduler), (latents.shape[0],), device=latents.device)

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -196,6 +196,11 @@ class StableDiffusion(ComposerModel):
             # Magical scaling number (See https://github.com/huggingface/diffusers/issues/437#issuecomment-1241827515)
             latents *= self.latent_scale
 
+        # Zero dropped captions if needed
+        conditioning *= batch['drop_caption_mask'].view(-1, 1, 1)
+        if pooled_conditioning is not None:
+            pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
+
         # Sample the diffusion timesteps
         timesteps = torch.randint(0, len(self.noise_scheduler), (latents.shape[0],), device=latents.device)
         # Add noise to the inputs (forward diffusion)


### PR DESCRIPTION
Previously when we applied caption dropout (via `caption_drop_prob` in the dataloader), those dropped captions (i.e. empty strings) would end up getting tokenized into padding tokens and encoded by the text encoder(s). This PR adds the option to instead encode the dropped captions as an all zeros tensor by setting `zero_dropped_caption=True`. Currently this flag is set such that zero-ing out dropped captions will become the new default behavior for both SD2 and SDXL training.