### PR TITLE
Allow masking padding tokens in cross attention layers

### DIFF
--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -163,7 +163,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         else:
             tokenized_caption = tokenized_caption.squeeze()
         out['captions'] = tokenized_caption
-        out['attention_mask'] = tokenizer_out['attention_mask'].squeeze()
+        out['attention_mask'] = tokenizer_out['attention_mask']
         return out
 
 

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -151,17 +151,19 @@ class StreamingImageCaptionDataset(StreamingDataset):
             out['drop_caption_mask'] = 1.0
 
         max_length = None if self.sdxl else self.tokenizer.model_max_length  # type: ignore
-        tokenized_caption = self.tokenizer(caption,
+        tokenizer_out = self.tokenizer(caption,
                                            padding='max_length',
                                            max_length=max_length,
                                            truncation=True,
-                                           return_tensors='pt')['input_ids']
+                                           return_tensors='pt')
+        tokenized_caption = tokenizer_out.input_ids
         if self.sdxl:
             tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenized_caption]
             tokenized_caption = torch.stack(tokenized_caption)
         else:
             tokenized_caption = tokenized_caption.squeeze()
         out['captions'] = tokenized_caption
+        out['attention_mask'] = tokenizer_out['attention_mask'].squeeze()
         return out
 
 

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -152,10 +152,10 @@ class StreamingImageCaptionDataset(StreamingDataset):
 
         max_length = None if self.sdxl else self.tokenizer.model_max_length  # type: ignore
         tokenizer_out = self.tokenizer(caption,
-                                           padding='max_length',
-                                           max_length=max_length,
-                                           truncation=True,
-                                           return_tensors='pt')
+                                       padding='max_length',
+                                       max_length=max_length,
+                                       truncation=True,
+                                       return_tensors='pt')
         tokenized_caption = tokenizer_out.input_ids
         if self.sdxl:
             tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenized_caption]
@@ -163,7 +163,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         else:
             tokenized_caption = tokenized_caption.squeeze()
         out['captions'] = tokenized_caption
-        out['attention_mask'] = tokenizer_out['attention_mask']
+        out['attention_mask'] = torch.tensor(tokenizer_out['attention_mask'])
         return out
 
 

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -159,11 +159,12 @@ class StreamingImageCaptionDataset(StreamingDataset):
         if self.sdxl:
             tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenizer_out.input_ids]
             tokenized_caption = torch.stack(tokenized_caption)
-            attention_mask = [mask.squeeze() for mask in tokenizer_out.attention_mask]
-            attention_mask = torch.stack(attention_mask)
+            # Take union over both tokenizers padding masks
+            attention_masks = tokenizer_out.attention_mask
+            attention_mask = torch.logical_or(attention_masks[0], attention_masks[1]).to(attention_masks[0].dtype)
         else:
             tokenized_caption = tokenizer_out.input_ids.squeeze()
-            attention_mask = tokenizer_out.attention_mask.squeeze()
+            attention_mask = tokenizer_out.attention_mask
         out['captions'] = tokenized_caption
         out['attention_mask'] = attention_mask
         return out

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -156,14 +156,16 @@ class StreamingImageCaptionDataset(StreamingDataset):
                                        max_length=max_length,
                                        truncation=True,
                                        return_tensors='pt')
-        tokenized_caption = tokenizer_out.input_ids
         if self.sdxl:
-            tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenized_caption]
+            tokenized_caption = [tokenized_cap.squeeze() for tokenized_cap in tokenizer_out.input_ids]
             tokenized_caption = torch.stack(tokenized_caption)
+            attention_mask = [mask.squeeze() for mask in tokenizer_out.attention_mask]
+            attention_mask = torch.stack(attention_mask)
         else:
-            tokenized_caption = tokenized_caption.squeeze()
+            tokenized_caption = tokenizer_out.input_ids.squeeze()
+            attention_mask = tokenizer_out.attention_mask.squeeze()
         out['captions'] = tokenized_caption
-        out['attention_mask'] = torch.tensor(tokenizer_out['attention_mask'])
+        out['attention_mask'] = attention_mask
         return out
 
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -41,6 +41,7 @@ def stable_diffusion_2(
     loss_bins: Optional[List] = None,
     precomputed_latents: bool = False,
     encode_latents_in_fp16: bool = True,
+    mask_pad_tokens: bool = False,
     fsdp: bool = True,
     clip_qkv: Optional[float] = None,
 ):
@@ -67,6 +68,7 @@ def stable_diffusion_2(
         offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
             be used. Default `None`.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
+        mask_pad_tokens (bool): Whether to mask pad tokens in cross attention. Defaults to False.
         fsdp (bool): Whether to use FSDP. Defaults to True.
         clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to None.
     """
@@ -123,6 +125,7 @@ def stable_diffusion_2(
         loss_bins=loss_bins,
         precomputed_latents=precomputed_latents,
         encode_latents_in_fp16=encode_latents_in_fp16,
+        mask_pad_tokens=mask_pad_tokens,
         fsdp=fsdp,
     )
     if torch.cuda.is_available():
@@ -156,6 +159,7 @@ def stable_diffusion_xl(
     loss_bins: Optional[List] = None,
     precomputed_latents: bool = False,
     encode_latents_in_fp16: bool = True,
+    mask_pad_tokens: bool = False,
     fsdp: bool = True,
     clip_qkv: Optional[float] = 6.0,
 ):
@@ -188,6 +192,7 @@ def stable_diffusion_xl(
             [(0, 1)].
         precomputed_latents (bool): Whether to use precomputed latents. Defaults to False.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
+        mask_pad_tokens (bool): Whether to mask pad tokens in cross attention. Defaults to False.
         fsdp (bool): Whether to use FSDP. Defaults to True.
         clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to 6.0. Improves stability
             of training.
@@ -259,6 +264,7 @@ def stable_diffusion_xl(
         loss_bins=loss_bins,
         precomputed_latents=precomputed_latents,
         encode_latents_in_fp16=encode_latents_in_fp16,
+        mask_pad_tokens=mask_pad_tokens,
         fsdp=fsdp,
         sdxl=True,
     )

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -241,7 +241,7 @@ class StableDiffusion(ComposerModel):
 
         # Forward through the model
         return self.unet(noised_latents, timesteps, conditioning,
-                         attention_mask=attention_mask,
+                         encoder_attention_mask=attention_mask,
                          added_cond_kwargs=added_cond_kwargs)['sample'], targets, timesteps
 
     def loss(self, outputs, batch):

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -64,6 +64,8 @@ class StableDiffusion(ComposerModel):
             Default: `False`.
         encode_latents_in_fp16 (bool): whether to encode latents in fp16.
             Default: `False`.
+        mask_pad_tokens (bool): whether to mask pad tokens in cross attention.
+            Default: `False`.
         sdxl (bool): Whether or not we're training SDXL. Default: `False`.
     """
 
@@ -88,6 +90,7 @@ class StableDiffusion(ComposerModel):
                  text_latents_key: str = 'caption_latents',
                  precomputed_latents: bool = False,
                  encode_latents_in_fp16: bool = False,
+                 mask_pad_tokens: bool = False,
                  fsdp: bool = False,
                  sdxl: bool = False):
         super().__init__()
@@ -103,6 +106,7 @@ class StableDiffusion(ComposerModel):
         self.image_key = image_key
         self.image_latents_key = image_latents_key
         self.precomputed_latents = precomputed_latents
+        self.mask_pad_tokens = mask_pad_tokens
         self.sdxl = sdxl
         if self.sdxl:
             self.latent_scale = 0.13025
@@ -152,6 +156,7 @@ class StableDiffusion(ComposerModel):
         self.text_key = text_key
         self.text_latents_key = text_latents_key
         self.encode_latents_in_fp16 = encode_latents_in_fp16
+        self.mask_pad_tokens = mask_pad_tokens
         # freeze text_encoder during diffusion training
         self.text_encoder.requires_grad_(False)
         self.vae.requires_grad_(False)
@@ -207,10 +212,10 @@ class StableDiffusion(ComposerModel):
                 pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
 
         # Attention mask if needed
-        if 'attention_mask' in batch.keys():
-            attention_mask = batch['attention_mask']
+        if self.mask_pad_tokens and 'attention_mask' in batch.keys():
+            encoder_attention_mask = batch['attention_mask']
         else:
-            attention_mask = None
+            encoder_attention_mask = None
 
         # Sample the diffusion timesteps
         timesteps = torch.randint(0, len(self.noise_scheduler), (latents.shape[0],), device=latents.device)
@@ -243,7 +248,7 @@ class StableDiffusion(ComposerModel):
         return self.unet(noised_latents,
                          timesteps,
                          conditioning,
-                         encoder_attention_mask=attention_mask,
+                         encoder_attention_mask=encoder_attention_mask,
                          added_cond_kwargs=added_cond_kwargs)['sample'], targets, timesteps
 
     def loss(self, outputs, batch):
@@ -261,6 +266,12 @@ class StableDiffusion(ComposerModel):
         prompts = batch[self.text_key]
         height, width = batch[self.image_key].shape[-2], batch[self.image_key].shape[-1]
 
+        # Attention mask if needed
+        if self.mask_pad_tokens and 'attention_mask' in batch.keys():
+            encoder_attention_mask = batch['attention_mask']
+        else:
+            encoder_attention_mask = None
+
         # If SDXL, add eval-time micro-conditioning to batch
         if self.sdxl:
             device = self.unet.device
@@ -275,6 +286,7 @@ class StableDiffusion(ComposerModel):
         generated_images = {}
         for guidance_scale in self.val_guidance_scales:
             gen_images = self.generate(tokenized_prompts=prompts,
+                                       tokenized_prompts_pad_mask=encoder_attention_mask,
                                        height=height,
                                        width=width,
                                        guidance_scale=guidance_scale,
@@ -348,6 +360,8 @@ class StableDiffusion(ComposerModel):
         negative_prompt: Optional[list] = None,
         tokenized_prompts: Optional[torch.LongTensor] = None,
         tokenized_negative_prompts: Optional[torch.LongTensor] = None,
+        tokenized_prompts_pad_mask: Optional[torch.LongTensor] = None,
+        tokenized_negative_prompts_pad_mask: Optional[torch.LongTensor] = None,
         prompt_embeds: Optional[torch.FloatTensor] = None,
         negative_prompt_embeds: Optional[torch.FloatTensor] = None,
         height: Optional[int] = None,
@@ -378,6 +392,10 @@ class StableDiffusion(ComposerModel):
                 otherwise will be of shape [B, max_length]. Default: `None`.
             tokenized_negative_prompts (torch.LongTensor): Optionally pass pre-tokenized negative
                 prompts instead of string prompts. Default: `None`.
+            tokenized_prompts_pad_mask (torch.LongTensor): Optionally pass padding mask for
+                pre-tokenized prompts. Default `None`.
+            tokenized_negative_prompts_pad_mask (torch.LongTensor): Optionall pass padding mask for
+                pre-tokenized negative prompts. Default `None`.
             prompt_embeds (torch.FloatTensor): Optionally pass pre-tokenized prompts instead
                 of string prompts. If both prompt and prompt_embeds
                 are passed, prompt_embeds will be used. Default: `None`.
@@ -432,11 +450,11 @@ class StableDiffusion(ComposerModel):
         do_classifier_free_guidance = guidance_scale > 1.0  # type: ignore
 
         text_embeddings, pooled_text_embeddings, pad_attn_mask = self._prepare_text_embeddings(
-            prompt, tokenized_prompts, prompt_embeds, num_images_per_prompt)
+            prompt, tokenized_prompts, tokenized_prompts_pad_mask, prompt_embeds, num_images_per_prompt)
         batch_size = len(text_embeddings)  # len prompts * num_images_per_prompt
         # classifier free guidance + negative prompts
         # negative prompt is given in place of the unconditional input in classifier free guidance
-        pooled_embeddings, encoder_attn_mask = None, None
+        pooled_embeddings, encoder_attn_mask = pooled_text_embeddings, pad_attn_mask
         if do_classifier_free_guidance:
             if not negative_prompt and not tokenized_negative_prompts and not negative_prompt_embeds and zero_out_negative_prompt:
                 # Negative prompt is empty and we want to zero it out
@@ -447,7 +465,8 @@ class StableDiffusion(ComposerModel):
                 if not negative_prompt:
                     negative_prompt = [''] * (batch_size // num_images_per_prompt)  # type: ignore
                 unconditional_embeddings, pooled_unconditional_embeddings, uncond_pad_attn_mask = self._prepare_text_embeddings(
-                    negative_prompt, tokenized_negative_prompts, negative_prompt_embeds, num_images_per_prompt)
+                    negative_prompt, tokenized_negative_prompts, tokenized_negative_prompts_pad_mask,
+                    negative_prompt_embeds, num_images_per_prompt)
 
             # concat uncond + prompt
             text_embeddings = torch.cat([unconditional_embeddings, text_embeddings])
@@ -456,9 +475,6 @@ class StableDiffusion(ComposerModel):
 
             if pad_attn_mask is not None:
                 encoder_attn_mask = torch.cat([uncond_pad_attn_mask, pad_attn_mask])  # type: ignore
-        else:
-            pooled_embeddings = pooled_text_embeddings
-            encoder_attn_mask = pad_attn_mask
 
         # prepare for diffusion generation process
         latents = torch.randn(
@@ -493,12 +509,11 @@ class StableDiffusion(ComposerModel):
 
             latent_model_input = self.inference_scheduler.scale_model_input(latent_model_input, t)
             # Model prediction
-            pred = self.unet(
-                latent_model_input,
-                t,
-                encoder_hidden_states=text_embeddings,
-                encoder_attention_mask=encoder_attn_mask,  # should be [B, 77]
-                added_cond_kwargs=added_cond_kwargs).sample
+            pred = self.unet(latent_model_input,
+                             t,
+                             encoder_hidden_states=text_embeddings,
+                             encoder_attention_mask=encoder_attn_mask,
+                             added_cond_kwargs=added_cond_kwargs).sample
 
             if do_classifier_free_guidance:
                 # perform guidance. Note this is only techincally correct for prediction_type 'epsilon'
@@ -520,10 +535,11 @@ class StableDiffusion(ComposerModel):
         image = (image / 2 + 0.5).clamp(0, 1)
         return image.detach()  # (batch*num_images_per_prompt, channel, h, w)
 
-    def _prepare_text_embeddings(self, prompt, tokenized_prompts, prompt_embeds, num_images_per_prompt):
+    def _prepare_text_embeddings(self, prompt, tokenized_prompts, tokenized_pad_mask, prompt_embeds,
+                                 num_images_per_prompt):
         """Tokenizes and embeds prompts if needed, then duplicates embeddings to support multiple generations per prompt."""
         device = self.text_encoder.device
-        pooled_text_embeddings, encoder_attn_mask = None, None
+        pooled_text_embeddings = None
         if prompt_embeds is None:
             max_length = None if self.sdxl else self.tokenizer.model_max_length
             if tokenized_prompts is None:
@@ -533,12 +549,14 @@ class StableDiffusion(ComposerModel):
                                                truncation=True,
                                                return_tensors='pt')
                 tokenized_prompts = tokenized_out.input_ids
-                encoder_attn_mask = tokenized_out.attention_mask
+                if self.mask_pad_tokens:
+                    tokenized_pad_mask = tokenized_out.attention_mask
                 if self.sdxl:
                     tokenized_prompts = torch.stack([tokenized_prompts[0], tokenized_prompts[1]], dim=1)
-                    # For cross attention mask, take union of masks (want [B, 77])
-                    encoder_attn_mask = torch.logical_or(encoder_attn_mask[0],
-                                                         encoder_attn_mask[1]).to(encoder_attn_mask[0].dtype).to(device)
+                    if self.mask_pad_tokens:
+                        # For cross attention mask, take union of masks (want [B, 77])
+                        tokenized_pad_mask = torch.logical_or(tokenized_pad_mask[0], tokenized_pad_mask[1]).to(
+                            tokenized_pad_mask[0].dtype).to(device)
             if self.sdxl:
                 text_embeddings, pooled_text_embeddings = self.text_encoder(
                     [tokenized_prompts[:, 0, :].to(device), tokenized_prompts[:, 1, :].to(device)])  # type: ignore
@@ -554,14 +572,14 @@ class StableDiffusion(ComposerModel):
         text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1)  # type: ignore
         text_embeddings = text_embeddings.view(bs_embed * num_images_per_prompt, seq_len, -1)
 
-        if encoder_attn_mask is not None:
-            encoder_attn_mask = encoder_attn_mask.repeat(1, num_images_per_prompt, 1)
-            encoder_attn_mask = encoder_attn_mask.view(bs_embed * num_images_per_prompt, seq_len)  # [B, 77]
+        if tokenized_pad_mask is not None:
+            tokenized_pad_mask = tokenized_pad_mask.repeat(1, num_images_per_prompt, 1)
+            tokenized_pad_mask = tokenized_pad_mask.view(bs_embed * num_images_per_prompt, seq_len)  # [B, 77]
 
         if self.sdxl and pooled_text_embeddings is not None:
             pooled_text_embeddings = pooled_text_embeddings.repeat(1, num_images_per_prompt)
             pooled_text_embeddings = pooled_text_embeddings.view(bs_embed * num_images_per_prompt, -1)
-        return text_embeddings, pooled_text_embeddings, encoder_attn_mask
+        return text_embeddings, pooled_text_embeddings, tokenized_pad_mask
 
 
 def _check_prompt_lenths(prompt, negative_prompt):


### PR DESCRIPTION
This PR adds a new parameter to the `stable_diffusion_xl` and `stable_diffusion_2` classes called `mask_pad_tokens` that allows for masking out padding tokens in cross attention layers. 

The `generate()` had to get a bit more complicated due to the setting where we pass in pre-tokenized inputs.. we'd now want to allow passing the padding mask with it (as well as for pre-tokenized negative prompts). Let me know if you think of a better way of handling this :/

One small note: this change might be slightly redundant with the `zero_out_negative_prompt` arg (in the generate() function) and `zero_dropped_captions` (in dataloader) that I added not too long ago for zero-ing out empty negative prompts and dropped captions. I think `mask_pad_tokens` ought to serve a similar purpose of masking out the empty text embeddings in the cross attention layers, however `zero_out_negative_prompt/zero_dropped_captions` additionally zero-out the pooled text embedding (used in SDXL as microconditioning). I think we still want to keep that functionality. The cleanest way would prob be to merge these all into one flag?