### PR TITLE
Better StreamingDataset defaults while preserving old shuffle settings

### DIFF
--- a/diffusion/datasets/coco/coco_captions.py
+++ b/diffusion/datasets/coco/coco_captions.py
@@ -22,23 +22,21 @@ class StreamingCOCOCaption(StreamingDataset):
             Default: ``None``.
         local (str, optional): Local filesystem directory where dataset is cached during operation.
             Default: ``None``.
-        split (str, optional): The dataset split to use. Currently, only ``None`` is supported.
-            Default: ``None``.
         shuffle (bool): Whether to shuffle the samples in this dataset.
             Default: ``False``.
-        tokenizer_name_or_path (str): The name or path of the tokenizer to use.
-            Default: ``'stabilityai/stable-diffusion-2-base'``.
-        transform (Optional[Callable]): The transforms to apply to the image.
-            Default: ``None``.
-        predownload (Optional[int]): The number of samples to prefetch.
-            Default: ``100_000``.
-        download_retry (Optional[int]): The number of times to retry a download.
-            Default: ``2``.
-        download_timeout (Optional[float]): The timeout for a download.
-            Default: ``120``.
+        shuffle_algo (str): What shuffle algorithm to use.
+            Default: ``'py1s'``.
+        shuffle_block_size (int): Unit of shuffling.
+            Default: ``1 << 18``.
         batch_size (Optional[int]):  batch_size that will be used on each device's DataLoader.
             Default: ``None``.
-        image_size (Optional[int]): The size to resize the image to.
+        tokenizer_name_or_path (str): The name or path of the tokenizer to use.
+            Default: ``'stabilityai/stable-diffusion-2-base'``.
+        caption_selection (str): Which caption to use for the image. Must be 'random' or 'first'.
+            Default: ``'first'``.
+        download_timeout (Optional[float]): The timeout for a download.
+            Default: ``120``.
+        transform (Optional[Callable]): The transforms to apply to the image.
             Default: ``None``.
         num_canonical_nodes (int, optional): The number of canonical nodes for shuffle.
             Default: ``None``.
@@ -50,7 +48,9 @@ class StreamingCOCOCaption(StreamingDataset):
         remote,
         local,
         shuffle,
-        batch_size,
+        shuffle_algo: str = 'py1s',
+        shuffle_block_size: int = 1 << 18,
+        batch_size=None,
         tokenizer_name_or_path='stabilityai/stable-diffusion-2-base',
         caption_selection='first',
         download_timeout=120,
@@ -61,6 +61,8 @@ class StreamingCOCOCaption(StreamingDataset):
             remote=remote,
             local=local,
             shuffle=shuffle,
+            shuffle_algo=shuffle_algo,
+            shuffle_block_size=shuffle_block_size,
             batch_size=batch_size,
             download_timeout=download_timeout,
             num_canonical_nodes=num_canonical_nodes,

--- a/diffusion/datasets/coco/coco_captions.py
+++ b/diffusion/datasets/coco/coco_captions.py
@@ -50,7 +50,7 @@ class StreamingCOCOCaption(StreamingDataset):
         shuffle,
         shuffle_algo: str = 'py1s',
         shuffle_block_size: int = 1 << 18,
-        batch_size=None,
+        batch_size: Optional[int] = None,
         tokenizer_name_or_path='stabilityai/stable-diffusion-2-base',
         caption_selection='first',
         download_timeout=120,

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -65,7 +65,13 @@ class StreamingImageCaptionDataset(StreamingDataset):
         zero_dropped_captions: bool = False,
         **streaming_kwargs,
     ) -> None:
-
+        
+        # Set defaults for vision-friendly streaming args.
+        if 'shuffle_block_size' not in streaming_kwargs:
+            streaming_kwargs['shuffle_block_size'] = 1 << 18
+        if 'shuffle_algo' not in streaming_kwargs:
+            streaming_kwargs['shuffle_algo'] = 'py1s'
+        
         super().__init__(
             streams=streams,
             remote=remote,

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -65,13 +65,11 @@ class StreamingImageCaptionDataset(StreamingDataset):
         zero_dropped_captions: bool = False,
         **streaming_kwargs,
     ) -> None:
-        
+
         # Set defaults for vision-friendly streaming args.
-        if 'shuffle_block_size' not in streaming_kwargs:
-            streaming_kwargs['shuffle_block_size'] = 1 << 18
-        if 'shuffle_algo' not in streaming_kwargs:
-            streaming_kwargs['shuffle_algo'] = 'py1s'
-        
+        streaming_kwargs.setdefault('shuffle_block_size', 1 << 18)
+        streaming_kwargs.setdefault('shuffle_algo', 'py1s')
+
         super().__init__(
             streams=streams,
             remote=remote,

--- a/diffusion/datasets/laion/laion.py
+++ b/diffusion/datasets/laion/laion.py
@@ -30,9 +30,11 @@ class StreamingLAIONDataset(StreamingDataset):
         local (str, optional): Local filesystem directory where dataset is cached during operation. Default: ``None``.
         split (str, optional): The dataset split to use. Currently, only ``None`` is supported. Default: ``None``.
         shuffle (bool): Whether to shuffle the samples in this dataset. Default: ``False``.
+        shuffle_algo (str): What shuffle algorithm to use. Default: ``'py1s'``.
+        shuffle_block_size (int): Unit of shuffling. Default: ``1 << 18``.
         tokenizer_name_or_path (str): The name or path of the tokenizer to use. Default: ``'stabilityai/stable-diffusion-2-base'``.
         transform (Optional[Callable]): The transforms to apply to the image. Default: ``None``.
-        predownload (Optional[int]): The number of samples to prefetch. Default: ``100_000``.
+        predownload (Optional[int]): The number of samples to prefetch. If ``None``, its value is set to ``8 * batch_size``. Default: ``None``.
         download_retry (Optional[int]): The number of times to retry a download. Default: ``2``.
         download_timeout (Optional[float]): The timeout for a download. Default: ``120``.
         batch_size (Optional[int]): Hint batch_size that will be used on each device's DataLoader. Default: ``None``.
@@ -47,10 +49,12 @@ class StreamingLAIONDataset(StreamingDataset):
         local: Optional[str] = None,
         split: Optional[str] = None,
         shuffle: bool = False,
+        shuffle_algo: str = 'py1s',
+        shuffle_block_size: int = 1 << 18,
         tokenizer_name_or_path: str = 'stabilityai/stable-diffusion-2-base',
         caption_drop_prob: float = 0.0,
         transform: Optional[Callable] = None,
-        predownload: int = 100_000,
+        predownload: Optional[int] = None,
         download_retry: int = 2,
         download_timeout: float = 120,
         batch_size: Optional[int] = None,
@@ -64,6 +68,8 @@ class StreamingLAIONDataset(StreamingDataset):
             local=local,
             split=split,
             shuffle=shuffle,
+            shuffle_algo=shuffle_algo,
+            shuffle_block_size=shuffle_block_size,
             predownload=predownload,
             keep_zip=False,
             download_retry=download_retry,

--- a/scripts/precompute_latents.py
+++ b/scripts/precompute_latents.py
@@ -33,9 +33,11 @@ class StreamingLAIONDataset(StreamingDataset):
         local (str, optional): Local filesystem directory where dataset is cached during operation. Default: ``None``.
         split (str, optional): The dataset split to use. Currently, only ``None`` is supported. Default: ``None``.
         shuffle (bool): Whether to shuffle the samples in this dataset. Default: ``False``.
+        shuffle_algo (str): What shuffle algorithm to use. Default: ``'py1s'``.
+        shuffle_block_size (int): Unit of shuffling. Default: ``1 << 18``.
         tokenizer_name_or_path (str): The name or path of the tokenizer to use. Default: ``'stabilityai/stable-diffusion-2-base'``.
         transform (Optional[Union[Callable, List[Callable]]]): The transforms to apply to the image. Default: ``None``.
-        predownload (Optional[int]): The number of samples to prefetch. Default: ``100_000``.
+        predownload (Optional[int]): The number of samples to prefetch. If ``None``, its value is set to ``8 * batch_size``. Default: ``None``.
         download_retry (Optional[int]): The number of times to retry a download. Default: ``2``.
         download_timeout (Optional[float]): The timeout for a download. Default: ``120``.
         batch_size (Optional[int]): Hint batch_size that will be used on each device's DataLoader. Default: ``None``.
@@ -47,10 +49,12 @@ class StreamingLAIONDataset(StreamingDataset):
                  local: Optional[str] = None,
                  split: Optional[str] = None,
                  shuffle: bool = False,
+                 shuffle_algo: str = 'py1s',
+                 shuffle_block_size: int = 1 << 18,
                  tokenizer_name_or_path: str = 'stabilityai/stable-diffusion-2-base',
                  caption_drop_prob: float = 0.0,
                  transform: Optional[List[Callable]] = None,
-                 predownload: int = 100_000,
+                 predownload: Optional[int] = None,
                  download_retry: int = 2,
                  download_timeout: float = 120,
                  batch_size: Optional[int] = None) -> None:
@@ -61,6 +65,8 @@ class StreamingLAIONDataset(StreamingDataset):
             local=local,
             split=split,
             shuffle=shuffle,
+            shuffle_algo=shuffle_algo,
+            shuffle_block_size=shuffle_block_size,
             predownload=predownload,
             keep_zip=False,
             download_retry=download_retry,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'mosaicml==0.16.3',
-    'mosaicml-streaming>=0.6.0,<1.0',
+    'mosaicml-streaming>=0.7.1,<1.0',
     'hydra-core>=1.2',
     'hydra-colorlog>=1.1.0',
     'diffusers[torch]==0.21.0',


### PR DESCRIPTION
This PR brings the improvements from Streaming v0.7.0 to diffusion while preserving the old shuffle settings that were being used. In detail:

Improvements:
* `relaxed` partitioning is now default. This allows for elastic determinism and resumption on many more numbers of nodes
* `predownload` is now defaulted lower, to `8 * batch_size` to ensure more balanced download demand
* Only when the shuffle algorithm is not `py1s` (the default) or `py2s`, `num_canonical_nodes` will be set to equal the number of physical nodes. Other than that, `num_canonical_nodes` is set the same way as before, to 64 * physical nodes.

Changes:
* `py1s` remains the default shuffle algorithm across this repo. `StreamingDataset` currently defaults to `py1e`. This is so that current workloads don't get messed up, and because `py1e` will be slower because vision datasets are usually much larger than NLP. I can change this after confirmation from you all!
* `shuffle_block_size` remains at 1 << 18 by default. Similar reasoning to above, so that your current workloads don't get messed up.

Happy to discuss these changes with y'all!

Streaming defaults were changed in this commit: https://github.com/mosaicml/streaming/commit/93bf0549bb1d36092a1488004917b594d2ad251e