### PR TITLE
LogDiffusionImages Features and Refactors

### DIFF
--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -3,7 +3,7 @@
 
 """Logger for generated images."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 
 import torch
 from composer import Callback, Logger, State
@@ -19,7 +19,8 @@ class LogDiffusionImages(Callback):
 
     Args:
         prompts (List[str]): List of prompts to use for evaluation.
-        size (int, optional): Image size to use during generation. Default: ``256``.
+        size (int, Tuple[int, int], optional): Image size to use during generation.
+            If using a tuple, specify as (height, width).  Default: ``256``.
         num_inference_steps (int, optional): Number of inference steps to use during generation. Default: ``50``.
         guidance_scale (float, optional): guidance_scale is defined as w of equation 2
             of the Imagen Paper. Guidance scale is enabled by setting guidance_scale > 1.
@@ -28,7 +29,6 @@ class LogDiffusionImages(Callback):
             Default: ``0.0``.
         rescaled_guidance (float, optional): Rescaled guidance scale. If not specified, rescaled guidance
             will not be used. Default: ``None``.
-        text_key (str, optional): Key in the batch to use for text prompts. Default: ``'captions'``.
         tokenized_prompts (torch.LongTensor or List[torch.LongTensor], optional): Batch of pre-tokenized prompts
             to use for evaluation. If SDXL, this will be a list of two pre-tokenized prompts Default: ``None``.
         seed (int, optional): Random seed to use for generation. Set a seed for reproducible generation.
@@ -38,62 +38,65 @@ class LogDiffusionImages(Callback):
 
     def __init__(self,
                  prompts: List[str],
-                 size: Optional[int] = 256,
+                 size: Optional[Union[Tuple[int, int], int]] = 256,
+                 batch_size: Optional[int] = None,
                  num_inference_steps=50,
                  guidance_scale: Optional[float] = 0.0,
                  rescaled_guidance: Optional[float] = None,
-                 text_key: Optional[str] = 'captions',
                  tokenized_prompts: Optional[torch.LongTensor] = None,
                  seed: Optional[int] = 1138,
                  use_table: bool = False):
         self.prompts = prompts
-        self.size = size
+        self.size = (size, size) if isinstance(size, int) else size
+        self.batch_size = len(prompts) if batch_size is None else batch_size
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale
         self.rescaled_guidance = rescaled_guidance
-        self.text_key = text_key
         self.seed = seed
         self.tokenized_prompts = tokenized_prompts
         self.use_table = use_table
 
-    def eval_batch_end(self, state: State, logger: Logger):
-        # Only log once per eval epoch
-        if state.eval_timestamp.get(TimeUnit.BATCH).value == 1:
-            # Get the model object if it has been wrapped by DDP
-            # We need this to access the text keys, tokenizer, and image generation function.
-            if isinstance(state.model, DistributedDataParallel):
-                model = state.model.module
+    def eval_start(self, state: State, logger: Logger):
+        # Get the model object if it has been wrapped by DDP
+        # We need this to access the text keys, tokenizer, and image generation function.
+        if isinstance(state.model, DistributedDataParallel):
+            model = state.model.module
+        else:
+            model = state.model
+
+        if self.tokenized_prompts is None:
+            self.tokenized_prompts = [
+                model.tokenizer(p, padding='max_length', truncation=True,
+                                return_tensors='pt')['input_ids']  # type: ignore
+                for p in self.prompts
+            ]
+            if model.sdxl:
+                self.tokenized_prompts = torch.stack([torch.cat(tp) for tp in self.tokenized_prompts
+                                                        ])  # [B, 2, max_length]
             else:
-                model = state.model
+                self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
 
-            if self.tokenized_prompts is None:
-                self.tokenized_prompts = [
-                    model.tokenizer(p, padding='max_length', truncation=True,
-                                    return_tensors='pt')['input_ids']  # type: ignore
-                    for p in self.prompts
-                ]
-                if model.sdxl:
-                    self.tokenized_prompts = torch.stack([torch.cat(tp) for tp in self.tokenized_prompts
-                                                         ])  # [B, 2, max_length]
-                else:
-                    self.tokenized_prompts = torch.cat(self.tokenized_prompts)  # type: ignore
-            self.tokenized_prompts = self.tokenized_prompts.to(state.batch[self.text_key].device)  # type: ignore
+        # Batch tokenized prompts
+        if not isinstance(self.tokenized_prompts, tuple):
+            self.tokenized_prompts = torch.split(self.tokenized_prompts, self.batch_size)
 
-            # Generate images
-            with get_precision_context(state.precision):
+
+        # Generate images
+        with get_precision_context(state.precision):
+            for tokenized_prompt_batch in self.tokenized_prompts:
                 gen_images = model.generate(
-                    tokenized_prompts=self.tokenized_prompts,  # type: ignore
-                    height=self.size,
-                    width=self.size,
+                    tokenized_prompts=tokenized_prompt_batch,  # type: ignore
+                    height=self.size[0],
+                    width=self.size[1],
                     guidance_scale=self.guidance_scale,
                     rescaled_guidance=self.rescaled_guidance,
                     progress_bar=False,
                     num_inference_steps=self.num_inference_steps,
                     seed=self.seed)
 
-            # Log images to wandb
-            for prompt, image in zip(self.prompts, gen_images):
-                logger.log_images(images=image, name=prompt, step=state.timestamp.batch.value, use_table=self.use_table)
+        # Log images to wandb
+        for prompt, image in zip(self.prompts, gen_images):
+            logger.log_images(images=image, name=prompt, step=state.timestamp.batch.value, use_table=self.use_table)
 
 
 class LogAutoencoderImages(Callback):

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -49,7 +49,7 @@ class LogDiffusionImages(Callback):
                  seed: Optional[int] = 1138,
                  use_table: bool = False):
         self.prompts = prompts
-        self.size = size if isinstance(size, tuple) else (size, size)
+        self.size = (size, size) if isinstance(size, int) else size
         self.batch_size = len(prompts) if batch_size is None else batch_size
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -19,12 +19,12 @@ class LogDiffusionImages(Callback):
 
     Args:
         prompts (List[str]): List of prompts to use for evaluation.
-        size (int, Tuple[int, int], optional): Image size to use during generation.
+        size (int, Tuple[int, int]): Image size to use during generation.
             If using a tuple, specify as (height, width).  Default: ``256``.
         batch_size (int, optional): The batch size of the prompts passed to the generate function. If set to ``None``,
             batch_size is equal to the number of prompts. Default: ``1``.
-        num_inference_steps (int, optional): Number of inference steps to use during generation. Default: ``50``.
-        guidance_scale (float, optional): guidance_scale is defined as w of equation 2
+        num_inference_steps (int): Number of inference steps to use during generation. Default: ``50``.
+        guidance_scale (float): guidance_scale is defined as w of equation 2
             of the Imagen Paper. Guidance scale is enabled by setting guidance_scale > 1.
             A larger guidance scale generates images that are more aligned to
             the text prompt, usually at the expense of lower image quality.

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -21,8 +21,8 @@ class LogDiffusionImages(Callback):
         prompts (List[str]): List of prompts to use for evaluation.
         size (int, Tuple[int, int], optional): Image size to use during generation.
             If using a tuple, specify as (height, width).  Default: ``256``.
-        batch_size (int, optional): The batch size of the prompts passed to the generate function. If not specified,
-            batch_size is set to the number of prompts. Default: ``None``.
+        batch_size (int, optional): The batch size of the prompts passed to the generate function. If set to ``None``,
+            batch_size is equal to the number of prompts. Default: ``1``.
         num_inference_steps (int, optional): Number of inference steps to use during generation. Default: ``50``.
         guidance_scale (float, optional): guidance_scale is defined as w of equation 2
             of the Imagen Paper. Guidance scale is enabled by setting guidance_scale > 1.
@@ -41,7 +41,7 @@ class LogDiffusionImages(Callback):
     def __init__(self,
                  prompts: List[str],
                  size: Union[Tuple[int, int], int] = 256,
-                 batch_size: Optional[int] = None,
+                 batch_size: Optional[int] = 1,
                  num_inference_steps: int = 50,
                  guidance_scale: float = 0.0,
                  rescaled_guidance: Optional[float] = None,

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -40,10 +40,10 @@ class LogDiffusionImages(Callback):
 
     def __init__(self,
                  prompts: List[str],
-                 size: Optional[Union[Tuple[int, int], int]] = 256,
+                 size: Union[Tuple[int, int], int] = 256,
                  batch_size: Optional[int] = None,
-                 num_inference_steps=50,
-                 guidance_scale: Optional[float] = 0.0,
+                 num_inference_steps: int = 50,
+                 guidance_scale: float = 0.0,
                  rescaled_guidance: Optional[float] = None,
                  tokenized_prompts: Optional[torch.LongTensor] = None,
                  seed: Optional[int] = 1138,

--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -48,7 +48,6 @@ class LogDiffusionImages(Callback):
                  use_table: bool = False):
         self.prompts = prompts
         self.size = (size, size) if isinstance(size, int) else size
-        self.batch_size = len(prompts) if batch_size is None else batch_size
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale
         self.rescaled_guidance = rescaled_guidance
@@ -56,6 +55,7 @@ class LogDiffusionImages(Callback):
         self.use_table = use_table
 
         # Batch prompts
+        batch_size = len(prompts) if batch_size is None else batch_size
         num_batches = ceil(len(prompts) / batch_size)
         self.batched_prompts = []
         for i in range(num_batches):


### PR DESCRIPTION
Adjustments to `LogDiffusionImages`

Features:
1. `batch_size` argument: batches the `prompts`, so we can generate more images at higher resolution
2. `size` argument accepts a tuple: allows us to specify non-square resolutions. I could make this a list of tuples if desired and we are okay with the complexity

Refactors (because I couldn't stop myself)
1. Removed `text_key` argument: we only used this to get the caption device and use this to move `tokenized_prompts`, but moving `tokenized_prompts` to the device should be handled in `generate()`
2. Changed the callback to run at `eval_start` instead of `eval_batch_end`. `eval_batch_end` required an if-statement to prevent logging images multiple times.