### PR TITLE
Add option to use E5 text encoder for SDXL

### DIFF
--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -43,7 +43,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_key (str): Key associated with the caption in the streaming dataset. Default: ``'caption'``.
         sdxl (bool): Whether or not we're training SDXL. Default: `False`.
-        use_e5 (bool): Whether to use e5-large-v2 tokenizer instead of openai CLIP. 
+        use_e5 (bool): Whether to use e5-large-v2 tokenizer instead of openai CLIP.
             Enable if using e5 text encoder. Defaults to False.
         zero_dropped_captions (bool): If True, zero out text embeddings for dropped captions. Default: ``False``.
 
@@ -202,6 +202,8 @@ def build_streaming_image_caption_dataloader(
         local (str, Sequence[str]): One or more local filesystem directories where dataset is cached during operation.
         batch_size (int): The batch size to use for both the ``StreamingDataset`` and ``DataLoader``.
         tokenizer_name_or_path (str): The name or path of the tokenizer to use. Default: ``'stabilityai/stable-diffusion-2-base'``.
+        use_e5 (bool): Whether to use e5-large-v2 tokenizer instead of openai CLIP.
+            Enable if using e5 text encoder. Defaults to False.
         caption_drop_prob (float): The probability of dropping a caption. Default: ``0.0``.
         microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL. Default: ``0.0``.
         resize_size (int): The size to resize the image to. Default: ``256``.

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -33,7 +33,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         remote (str, optional): Remote directory (S3 or local filesystem) where dataset is stored. Default: ``None``.
         local (str, optional): Local filesystem directory where dataset is cached during operation. Default: ``None``.
         tokenizer_name_or_path (str): The name or path of the tokenizer to use.
-          ``'stabilityai/stable-diffusion-2-base'``, ``'stabilityai/stable-diffusion-xl-base-1.0'`` or ``'sdxl-e5'``. 
+          ``'stabilityai/stable-diffusion-2-base'``, ``'stabilityai/stable-diffusion-xl-base-1.0'`` or ``'sdxl-e5'``.
             Default: ``'stabilityai/stable-diffusion-2-base'``.
         caption_drop_prob (float): The probability of dropping a caption. Default: ``0.0``.
         microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL. Default: ``0.0``.
@@ -198,8 +198,8 @@ def build_streaming_image_caption_dataloader(
         local (str, Sequence[str]): One or more local filesystem directories where dataset is cached during operation.
         batch_size (int): The batch size to use for both the ``StreamingDataset`` and ``DataLoader``.
         tokenizer_name_or_path (str): The name or path of the tokenizer to use.
-          ``'stabilityai/stable-diffusion-2-base'``, ``'stabilityai/stable-diffusion-xl-base-1.0'`` or ``'sdxl-e5'``. 
-            Default: ``'stabilityai/stable-diffusion-2-base'``.        
+          ``'stabilityai/stable-diffusion-2-base'``, ``'stabilityai/stable-diffusion-xl-base-1.0'`` or ``'sdxl-e5'``.
+            Default: ``'stabilityai/stable-diffusion-2-base'``.
         caption_drop_prob (float): The probability of dropping a caption. Default: ``0.0``.
         microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL. Default: ``0.0``.
         resize_size (int): The size to resize the image to. Default: ``256``.
@@ -290,6 +290,5 @@ def build_streaming_image_caption_dataloader(
 
 
 def _is_sdxl(tokenizer_name_or_path):
-    """Infer SDXL from tokenizer path"""
-    return (tokenizer_name_or_path == 'stabilityai/stable-diffusion-xl-base-1.0' or 
-            tokenizer_name_or_path == 'sdxl-e5')
+    """Infer SDXL from tokenizer path."""
+    return (tokenizer_name_or_path == 'stabilityai/stable-diffusion-xl-base-1.0' or tokenizer_name_or_path == 'sdxl-e5')

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -62,6 +62,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         image_key: str = 'image',
         caption_key: str = 'caption',
         sdxl: bool = False,
+        use_e5: bool = False,
         zero_dropped_captions: bool = False,
         **streaming_kwargs,
     ) -> None:
@@ -87,7 +88,7 @@ class StreamingImageCaptionDataset(StreamingDataset):
         self.zero_dropped_captions = zero_dropped_captions
 
         if self.sdxl:
-            self.tokenizer = SDXLTokenizer(tokenizer_name_or_path)
+            self.tokenizer = SDXLTokenizer(tokenizer_name_or_path, use_e5=use_e5)
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, subfolder='tokenizer')
 
@@ -175,6 +176,7 @@ def build_streaming_image_caption_dataloader(
     local: Union[str, List],
     batch_size: int,
     tokenizer_name_or_path: str = 'stabilityai/stable-diffusion-2-base',
+    use_e5: bool = False,
     caption_drop_prob: float = 0.0,
     microcond_drop_prob: float = 0.0,
     resize_size: int = 256,
@@ -268,6 +270,7 @@ def build_streaming_image_caption_dataloader(
         caption_key=caption_key,
         batch_size=batch_size,
         sdxl=sdxl,
+        use_e5=use_e5,
         zero_dropped_captions=zero_dropped_captions,
         **streaming_kwargs,
     )

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -242,6 +242,8 @@ def build_streaming_image_caption_dataloader(
     sdxl = (tokenizer_name_or_path == 'stabilityai/stable-diffusion-xl-base-1.0')
     if sdxl:
         log.info('Detected SDXL tokenizer, using SDXL crop transform and tokenizers.')
+        if use_e5:
+            log.info('Using E5 text encoder')
 
     # Set the crop to apply
     if crop_type == 'square':

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -89,7 +89,8 @@ class StreamingImageCaptionDataset(StreamingDataset):
         self.caption_key = caption_key
         self.zero_dropped_captions = zero_dropped_captions
 
-        if _is_sdxl(tokenizer_name_or_path):
+        self.sdxl = _is_sdxl(tokenizer_name_or_path)
+        if self.sdxl:
             self.tokenizer = SDXLTokenizer(tokenizer_name_or_path)
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, subfolder='tokenizer')

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -43,6 +43,8 @@ class StreamingImageCaptionDataset(StreamingDataset):
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_key (str): Key associated with the caption in the streaming dataset. Default: ``'caption'``.
         sdxl (bool): Whether or not we're training SDXL. Default: `False`.
+        use_e5 (bool): Whether to use e5-large-v2 tokenizer instead of openai CLIP. 
+            Enable if using e5 text encoder. Defaults to False.
         zero_dropped_captions (bool): If True, zero out text embeddings for dropped captions. Default: ``False``.
 
         **streaming_kwargs: Additional arguments to pass in the construction of the StreamingDataloader

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -216,9 +216,9 @@ def stable_diffusion_xl(
         unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
     else:
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
-        if use_e5:
-            config[0]['projection_class_embeddings_input_dim'] = 2048
-            config[0]['cross_attention_dim'] = 2304
+        # if use_e5:
+            # config[0]['projection_class_embeddings_input_dim'] = 2048
+            # config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
         print('projection_class_embeddings_input_dim:', unet.config['projection_class_embeddings_input_dim'])
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -550,11 +550,11 @@ class SDXLTextEncoder(torch.nn.Module):
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', encode_latents_in_fp16=True, use_e5=False):
         super().__init__()
         torch_dtype = torch.float16 if encode_latents_in_fp16 else None
-        self.text_encoder = CLIPTextModel.from_pretrained(model_name, subfolder='text_encoder', torch_dtype=torch_dtype)
         if use_e5:
-            self.text_encoder_2 = AutoModel.from_pretrained('intfloat/e5-large-v2', torch_dtype=torch_dtype)
+            self.text_encoder = AutoModel.from_pretrained('intfloat/e5-large-v2', torch_dtype=torch_dtype)
         else:
-            self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(model_name,
+            self.text_encoder = CLIPTextModel.from_pretrained(model_name, subfolder='text_encoder', torch_dtype=torch_dtype)
+        self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(model_name,
                                                                           subfolder='text_encoder_2',
                                                                           torch_dtype=torch_dtype)
 
@@ -584,24 +584,24 @@ class SDXLTokenizer:
     """
 
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', use_e5=False):
-        self.tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
         if use_e5:
-            self.tokenizer_2 = AutoTokenizer.from_pretrained('intfloat/e5-large-v2')
+            self.tokenizer = AutoTokenizer.from_pretrained('intfloat/e5-large-v2')
         else:
-            self.tokenizer_2 = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer_2')
+            self.tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
+        self.tokenizer_2 = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer_2')
 
 
     def __call__(self, prompt, padding, truncation, return_tensors, max_length=None):
         tokenized_output = self.tokenizer(
             prompt,
             padding=padding,
-            max_length=self.tokenizer.model_max_length if max_length is None else max_length,
+            max_length=self.tokenizer_2.model_max_length if max_length is None else max_length,
             truncation=truncation,
             return_tensors=return_tensors)
         tokenized_output_2 = self.tokenizer_2(
             prompt,
             padding=padding,
-            max_length=self.tokenizer.model_max_length if max_length is None else max_length,
+            max_length=self.tokenizer_2.model_max_length if max_length is None else max_length,
             truncation=truncation,
             return_tensors=return_tensors)
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -220,7 +220,7 @@ def stable_diffusion_xl(
             config[0]['projection_class_embeddings_input_dim'] = 2048
             config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
-        print('projection_class_embeddings_input_dim:', unet.config[0]['projection_class_embeddings_input_dim'])
+        print('projection_class_embeddings_input_dim:', unet.config['projection_class_embeddings_input_dim'])
 
         # Zero initialization trick
         for name, layer in unet.named_modules():

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -594,13 +594,14 @@ class SDXLTokenizer:
     Tokenizes prompt with two tokenizers and returns the joined output.
 
     Args:
-        model_name (str): Name of the model's text encoders to load. Defaults to 'stabilityai/stable-diffusion-xl-base-1.0'.
-        use_e5 (bool): Whether to use e5-large-v2 tokenizer instead of openai CLIP.
-            Enable if using e5 text encoder. Defaults to False.
+        model_name (str): Name of the model's text encoders to load. 
+            'sdxl-e5' or 'stabilityai/stable-diffusion-xl-base-1.0'.
+            Default: 'stabilityai/stable-diffusion-xl-base-1.0'.
     """
 
-    def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', use_e5=False):
-        if use_e5:
+    def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0'):
+        _validate_model_name(model_name)
+        if model_name=='sdxl-e5':
             self.tokenizer = AutoTokenizer.from_pretrained('intfloat/e5-large-v2')
         else:
             self.tokenizer = CLIPTokenizer.from_pretrained(model_name, subfolder='tokenizer')
@@ -624,3 +625,9 @@ class SDXLTokenizer:
         for key in tokenized_output_2.keys():
             tokenized_output[key] = [tokenized_output[key], tokenized_output_2[key]]
         return tokenized_output
+
+def _validate_model_name(model_name):
+    valid_model_names = {'sdxl-e5', 'stabilityai/stable-diffusion-xl-base-1.0'}
+    if model_name not in valid_model_names:
+        raise ValueError(f'model_name must be one of {valid_model_names}.')
+

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -606,6 +606,6 @@ class SDXLTokenizer:
             return_tensors=return_tensors)
 
         # Add second tokenizer output to first tokenizer
-        for key in tokenized_output.keys():
+        for key in tokenized_output_2.keys():
             tokenized_output[key] = [tokenized_output[key], tokenized_output_2[key]]
         return tokenized_output

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -181,6 +181,7 @@ def stable_diffusion_xl(
         vae_model_name (str): Name of the VAE model to load. Defaults to
             'madebyollin/sdxl-vae-fp16-fix' as the official VAE checkpoint (from
             'stabilityai/stable-diffusion-xl-base-1.0') is not compatible with fp16.
+        use_e5 (bool): Whether to use e5-large-v2 text encoder instead of openai CLIP. Defaults to False.
         pretrained (bool): Whether to load pretrained weights. Defaults to True.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
@@ -553,6 +554,7 @@ class SDXLTextEncoder(torch.nn.Module):
     Args:
         model_name (str): Name of the model's text encoders to load. Defaults to 'stabilityai/stable-diffusion-xl-base-1.0'.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
+        use_e5 (bool): Whether to use e5-large-v2 text encoder instead of openai CLIP. Defaults to False.
     """
 
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', encode_latents_in_fp16=True, use_e5=False):

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -314,7 +314,7 @@ def stable_diffusion_xl(
             unet_config['in_channels'] = vae.config['latent_channels']
             unet_config['out_channels'] = vae.config['latent_channels']
         if model_name == 'sdxl-e5':  # e5 + clip embedding dims + micro conditioning
-            unet_config]['cross_attention_dim'] = 2304
+            unet_config['cross_attention_dim'] = 2304
         # Init the unet from the config
         unet = UNet2DConditionModel(**unet_config)
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -216,9 +216,9 @@ def stable_diffusion_xl(
         unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
     else:
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
-        # if use_e5:
+        if use_e5:
             # config[0]['projection_class_embeddings_input_dim'] = 2048
-            # config[0]['cross_attention_dim'] = 2304
+            config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
         print('projection_class_embeddings_input_dim:', unet.config['projection_class_embeddings_input_dim'])
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -216,6 +216,8 @@ def stable_diffusion_xl(
         unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
     else:
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
+        if use_e5:
+            config[0]['projection_class_embeddings_input_dim'] = 2048
         unet = UNet2DConditionModel(**config[0])
 
         # Zero initialization trick

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -218,6 +218,7 @@ def stable_diffusion_xl(
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
         if use_e5:
             config[0]['projection_class_embeddings_input_dim'] = 2048
+            config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
 
         # Zero initialization trick

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -220,6 +220,7 @@ def stable_diffusion_xl(
             config[0]['projection_class_embeddings_input_dim'] = 2048
             config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
+        print('projection_class_embeddings_input_dim:', unet.config[0]['projection_class_embeddings_input_dim'])
 
         # Zero initialization trick
         for name, layer in unet.named_modules():

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -221,7 +221,7 @@ def stable_diffusion_xl(
         unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
     else:
         config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')
-        if model_name=='sdxl-e5':   # e5 + clip embedding dims + micro conditioning
+        if model_name == 'sdxl-e5':  # e5 + clip embedding dims + micro conditioning
             config[0]['cross_attention_dim'] = 2304
         unet = UNet2DConditionModel(**config[0])
         # Zero initialization trick
@@ -244,7 +244,7 @@ def stable_diffusion_xl(
     tokenizer = SDXLTokenizer(model_name)
     text_encoder = SDXLTextEncoder(model_name, encode_latents_in_fp16)
 
-    scheduler_model_name = 'stabilityai/stable-diffusion-xl-base-1.0' if  model_name=='sdxl-e5' else model_name
+    scheduler_model_name = 'stabilityai/stable-diffusion-xl-base-1.0' if model_name == 'sdxl-e5' else model_name
     noise_scheduler = DDPMScheduler.from_pretrained(scheduler_model_name, subfolder='scheduler')
     inference_noise_scheduler = EulerDiscreteScheduler(num_train_timesteps=1000,
                                                        beta_start=0.00085,
@@ -550,21 +550,19 @@ class SDXLTextEncoder(torch.nn.Module):
     Creates two text encoders (a CLIPTextModel and CLIPTextModelWithProjection) that behave like one.
 
     Args:
-        model_name (str): Name of the model's text encoders to load. 
+        model_name (str): Name of the model's text encoders to load.
             'sdxl-e5' or 'stabilityai/stable-diffusion-xl-base-1.0'.
-            Default: 'stabilityai/stable-diffusion-xl-base-1.0'.        
+            Default: 'stabilityai/stable-diffusion-xl-base-1.0'.
         encode_latents_in_fp16 (bool): Whether to encode latents in fp16. Defaults to True.
     """
 
-    def __init__(self,
-                 model_name='stabilityai/stable-diffusion-xl-base-1.0',
-                 encode_latents_in_fp16=True):
+    def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0', encode_latents_in_fp16=True):
         super().__init__()
         _validate_model_name(model_name)
         torch_dtype = torch.float16 if encode_latents_in_fp16 else None
-        if model_name=='sdxl-e5':
+        if model_name == 'sdxl-e5':
             self.text_encoder = AutoModel.from_pretrained('intfloat/e5-large-v2', torch_dtype=torch_dtype)
-            model_name = 'stabilityai/stable-diffusion-xl-base-1.0' # set model name to sdxl to pull other encoder
+            model_name = 'stabilityai/stable-diffusion-xl-base-1.0'  # set model name to sdxl to pull other encoder
         else:
             self.text_encoder = CLIPTextModel.from_pretrained(model_name,
                                                               subfolder='text_encoder',
@@ -595,14 +593,14 @@ class SDXLTokenizer:
     Tokenizes prompt with two tokenizers and returns the joined output.
 
     Args:
-        model_name (str): Name of the model's tokenizers to load. 
+        model_name (str): Name of the model's tokenizers to load.
             'sdxl-e5' or 'stabilityai/stable-diffusion-xl-base-1.0'.
             Default: 'stabilityai/stable-diffusion-xl-base-1.0'.
     """
 
     def __init__(self, model_name='stabilityai/stable-diffusion-xl-base-1.0'):
         _validate_model_name(model_name)
-        if model_name=='sdxl-e5':
+        if model_name == 'sdxl-e5':
             self.tokenizer = AutoTokenizer.from_pretrained('intfloat/e5-large-v2')
             model_name = 'stabilityai/stable-diffusion-xl-base-1.0'
         else:
@@ -628,8 +626,8 @@ class SDXLTokenizer:
             tokenized_output[key] = [tokenized_output[key], tokenized_output_2[key]]
         return tokenized_output
 
+
 def _validate_model_name(model_name):
     valid_model_names = {'sdxl-e5', 'stabilityai/stable-diffusion-xl-base-1.0'}
     if model_name not in valid_model_names:
         raise ValueError(f'model_name must be one of {valid_model_names}.')
-

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -207,9 +207,9 @@ class StableDiffusion(ComposerModel):
 
         # Zero dropped captions if needed
         if 'drop_caption_mask' in batch.keys():
-            conditioning *= batch['drop_caption_mask']
+            conditioning *= batch['drop_caption_mask'][0]
             if pooled_conditioning is not None:
-                pooled_conditioning *= batch['drop_caption_mask']
+                pooled_conditioning *= batch['drop_caption_mask'][0]
 
         # Attention mask if needed
         if self.mask_pad_tokens and 'attention_mask' in batch.keys():

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -207,9 +207,9 @@ class StableDiffusion(ComposerModel):
 
         # Zero dropped captions if needed
         if 'drop_caption_mask' in batch.keys():
-            conditioning *= batch['drop_caption_mask'].view(-1, 1, 1)
+            conditioning *= batch['drop_caption_mask']
             if pooled_conditioning is not None:
-                pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
+                pooled_conditioning *= batch['drop_caption_mask']
 
         # Attention mask if needed
         if self.mask_pad_tokens and 'attention_mask' in batch.keys():

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -207,9 +207,9 @@ class StableDiffusion(ComposerModel):
 
         # Zero dropped captions if needed
         if 'drop_caption_mask' in batch.keys():
-            conditioning *= batch['drop_caption_mask'][0]
+            conditioning *= batch['drop_caption_mask'].view(-1, 1, 1)
             if pooled_conditioning is not None:
-                pooled_conditioning *= batch['drop_caption_mask'][0]
+                pooled_conditioning *= batch['drop_caption_mask'].view(-1, 1)
 
         # Attention mask if needed
         if self.mask_pad_tokens and 'attention_mask' in batch.keys():

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -260,8 +260,6 @@ class StableDiffusion(ComposerModel):
         # Skip this if outputs have already been computed, e.g. during training
         if outputs is not None:
             return outputs
-        # Get unet outputs
-        unet_out, targets, timesteps = self.forward(batch)
         # Sample images from the prompts in the batch
         prompts = batch[self.text_key]
         height, width = batch[self.image_key].shape[-2], batch[self.image_key].shape[-1]
@@ -282,6 +280,8 @@ class StableDiffusion(ComposerModel):
             batch['cond_crops_coords_top_left'] = torch.tensor([[0., 0.]]).repeat(bsz, 1).to(device)
             # Set to resolution we are trying to generate
             batch['cond_target_size'] = torch.tensor([[width, height]]).repeat(bsz, 1).to(device)
+
+        unet_out, targets, timesteps = self.forward(batch)
 
         generated_images = {}
         for guidance_scale in self.val_guidance_scales:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,9 +46,9 @@ def test_model_generate(guidance_scale, negative_prompt):
     assert output.shape == (1, 3, 8, 8)
 
 
-@pytest.mark.parametrize('use_e5', [True, False])
-def test_model_forward_sdxl(use_e5):
-    model = stable_diffusion_xl(use_e5=use_e5,
+@pytest.mark.parametrize(model_name, ['stabilityai/stable-diffusion-xl-base-1.0', 'sdxl-e5'])
+def test_model_forward_sdxl(model_name):
+    model = stable_diffusion_xl(model_name=model_name,
                                 pretrained=False,
                                 fsdp=False,
                                 encode_latents_in_fp16=False,
@@ -64,7 +64,7 @@ def test_model_forward_sdxl(use_e5):
     ), dtype=torch.long)
     caption = torch.stack([caption, caption], dim=1)
     micro_conditioning = torch.randint(1, H, (batch_size, 2))
-
+    
     batch = {
         'image': image,
         'captions': caption,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -64,7 +64,6 @@ def test_model_forward_sdxl(use_e5):
     ), dtype=torch.long)
     caption = torch.stack([caption, caption], dim=1)
     micro_conditioning = torch.randint(1, H, (batch_size, 2))
-    
 
     batch = {
         'image': image,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,7 +46,7 @@ def test_model_generate(guidance_scale, negative_prompt):
     assert output.shape == (1, 3, 8, 8)
 
 @pytest.mark.parametrize('use_e5', [True, False])
-def test_model_forward(use_e5):
+def test_model_forward_sdxl(use_e5):
     model = stable_diffusion_xl(use_e5=use_e5, pretrained=False, fsdp=False, encode_latents_in_fp16=False, clip_qkv=None)
     batch_size = 1
     H = 32

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,7 +7,7 @@
 import pytest
 import torch
 
-from diffusion.models.models import stable_diffusion_2
+from diffusion.models.models import stable_diffusion_2, stable_diffusion_xl
 
 
 def test_model_forward():
@@ -44,3 +44,26 @@ def test_model_generate(guidance_scale, negative_prompt):
         progress_bar=False,
     )
     assert output.shape == (1, 3, 8, 8)
+
+@pytest.mark.parametrize('use_e5', [True, False])
+def test_model_forward(use_e5):
+    model = stable_diffusion_xl(use_e5=use_e5, pretrained=False, fsdp=False, encode_latents_in_fp16=False, clip_qkv=None)
+    batch_size = 1
+    H = 32
+    W = 32
+    image = torch.randn(batch_size, 3, H, W)
+    latent = torch.randn(batch_size, 4, H // 8, W // 8)
+    caption = torch.randint(low=0, high=128, size=(
+        batch_size,
+        77,
+    ), dtype=torch.long)
+    randfloat = torch.randn(batch_size, 1)
+    caption = torch.stack([caption, caption], dim=1)
+    batch = {'image': image,
+            'captions': caption,
+            'cond_original_size': randfloat,
+            'cond_crops_coords_top_left': randfloat,
+            'cond_target_size': randfloat}
+    output, target, _ = model(batch)  # model.forward generates the unet output noise or v_pred target.
+    assert output.shape == latent.shape
+    assert target.shape == latent.shape

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -64,7 +64,7 @@ def test_model_forward_sdxl(model_name):
     ), dtype=torch.long)
     caption = torch.stack([caption, caption], dim=1)
     micro_conditioning = torch.randint(1, H, (batch_size, 2))
-    
+
     batch = {
         'image': image,
         'captions': caption,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,7 +46,7 @@ def test_model_generate(guidance_scale, negative_prompt):
     assert output.shape == (1, 3, 8, 8)
 
 
-@pytest.mark.parametrize(model_name, ['stabilityai/stable-diffusion-xl-base-1.0', 'sdxl-e5'])
+@pytest.mark.parametrize('model_name', ['stabilityai/stable-diffusion-xl-base-1.0', 'sdxl-e5'])
 def test_model_forward_sdxl(model_name):
     model = stable_diffusion_xl(model_name=model_name,
                                 pretrained=False,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -62,14 +62,16 @@ def test_model_forward_sdxl(use_e5):
         batch_size,
         77,
     ), dtype=torch.long)
-    randfloat = torch.randn(batch_size, 1)
     caption = torch.stack([caption, caption], dim=1)
+    micro_conditioning = torch.randint(1, H, (batch_size, 2))
+    
+
     batch = {
         'image': image,
         'captions': caption,
-        'cond_original_size': randfloat,
-        'cond_crops_coords_top_left': randfloat,
-        'cond_target_size': randfloat
+        'cond_original_size': micro_conditioning,
+        'cond_crops_coords_top_left': micro_conditioning,
+        'cond_target_size': micro_conditioning
     }
     output, target, _ = model(batch)  # model.forward generates the unet output noise or v_pred target.
     assert output.shape == latent.shape

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -45,9 +45,14 @@ def test_model_generate(guidance_scale, negative_prompt):
     )
     assert output.shape == (1, 3, 8, 8)
 
+
 @pytest.mark.parametrize('use_e5', [True, False])
 def test_model_forward_sdxl(use_e5):
-    model = stable_diffusion_xl(use_e5=use_e5, pretrained=False, fsdp=False, encode_latents_in_fp16=False, clip_qkv=None)
+    model = stable_diffusion_xl(use_e5=use_e5,
+                                pretrained=False,
+                                fsdp=False,
+                                encode_latents_in_fp16=False,
+                                clip_qkv=None)
     batch_size = 1
     H = 32
     W = 32
@@ -59,11 +64,13 @@ def test_model_forward_sdxl(use_e5):
     ), dtype=torch.long)
     randfloat = torch.randn(batch_size, 1)
     caption = torch.stack([caption, caption], dim=1)
-    batch = {'image': image,
-            'captions': caption,
-            'cond_original_size': randfloat,
-            'cond_crops_coords_top_left': randfloat,
-            'cond_target_size': randfloat}
+    batch = {
+        'image': image,
+        'captions': caption,
+        'cond_original_size': randfloat,
+        'cond_crops_coords_top_left': randfloat,
+        'cond_target_size': randfloat
+    }
     output, target, _ = model(batch)  # model.forward generates the unet output noise or v_pred target.
     assert output.shape == latent.shape
     assert target.shape == latent.shape


### PR DESCRIPTION
adds a simple switch to use e5 text encoder with SDXL. this is accomplished by splicing e5 into our joint text encoder class. Currently, this approach has some limitations:
- I wanted to avoid changing the API + building out a large registry or text encoders so only e5-large-v2 is currently supported. (t5 and other text encoders i tester were not supported by automodel/autotokenizer so I opted to keep it simple for now and leave them out.
- decided to stick with openclip vs openai clip as the HF model supports the projection layer needed for SDXL out of the box
- truncate sequence max-length to 77 (clip max len) vs 512 (e5 max length).

~to enable e5 add `use_e5: true` to both your dataset and model.~

after feedback, `model_name` and `tokenizer_name_or_path` now need to be updated to `sdxl-e5` to enable e5 training.