### PR TITLE
Remove rounding in aspect ratio bucketing transform

### DIFF
--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -58,7 +58,6 @@ class RandomCropAspectRatioTransorm:
             1088, 1024, 1024, 960, 960, 896, 896, 832, 832, 768, 768, 704, 704, 640, 640, 576, 576, 576, 512, 512, 512,
             512
         ])
-        # torch.round is a temporarily needed due to an artifact in our first batch of bucketing
         self.aspect_ratio_buckets = self.height_buckets / self.width_buckets
 
     def __call__(self, img):

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -59,7 +59,7 @@ class RandomCropAspectRatioTransorm:
             512
         ])
         # torch.round is a temporarily needed due to an artifact in our first batch of bucketing
-        self.aspect_ratio_buckets = torch.round(self.height_buckets / self.width_buckets, decimals=2)
+        self.aspect_ratio_buckets = self.height_buckets / self.width_buckets
 
     def __call__(self, img):
         orig_w, orig_h = img.size


### PR DESCRIPTION
I initially used `torch.round` since I used rounded aspect ratio buckets for the first LAION bucketing. With the updated LAION and Shutterstocks, there are no more rounded buckets so `torch.round` needs to be removed.