### PR TITLE
Add algorithm to control randomness over different eval times

### DIFF
--- a/diffusion/algorithms/pin_diffusion_rng.py
+++ b/diffusion/algorithms/pin_diffusion_rng.py
@@ -3,7 +3,7 @@
 
 """Algorithm to pin diffusion process noise."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch
 from composer.core import Algorithm, Event, State
@@ -18,8 +18,8 @@ class PinDiffusionRNG(Algorithm):
 
     def __init__(self) -> None:
         self.seed = 0
-        self.train_rng_state = None
-        self.eval_rng_state = None
+        self.train_rng_state: Optional[torch.Tensor] = None
+        self.eval_rng_state: Optional[torch.Tensor] = None
         self.train_rng_generator = torch.Generator()
         self.eval_rng_generator = torch.Generator()
 

--- a/diffusion/algorithms/pin_diffusion_rng.py
+++ b/diffusion/algorithms/pin_diffusion_rng.py
@@ -48,6 +48,8 @@ class PinDiffusionRNG(Algorithm):
                 self.train_rng_generator.set_state(self.train_rng_state)
             if self.eval_rng_state is not None:
                 self.eval_rng_generator.set_state(self.eval_rng_state)
+            # Set the train rng generator
+            model.set_rng_generator(self.train_rng_generator)
         elif event == Event.EVAL_START:
             # Reset the eval rng generator to ensure the same randomness is used every eval epoch
             self.eval_rng_generator = self.eval_rng_generator.manual_seed(self.seed)

--- a/diffusion/algorithms/pin_diffusion_rng.py
+++ b/diffusion/algorithms/pin_diffusion_rng.py
@@ -1,0 +1,68 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Algorithm to pin diffusion process noise."""
+
+from typing import Any, Dict
+
+import torch
+from composer.core import Algorithm, Event, State
+from composer.loggers import Logger
+from composer.utils import dist
+
+from diffusion.models import StableDiffusion
+
+
+class PinDiffusionRNG(Algorithm):
+    """Algorithm to pin diffusion process noise."""
+
+    def __init__(self) -> None:
+        self.seed = 0
+        self.train_rng_state = None
+        self.eval_rng_state = None
+        self.train_rng_generator = torch.Generator()
+        self.eval_rng_generator = torch.Generator()
+
+    def match(self, event: Event, state: State) -> bool:
+        return event in (Event.INIT, Event.EVAL_START, Event.EVAL_END)
+
+    def apply(self, event: Event, state: State, logger: Logger) -> None:
+        if hasattr(state.model, 'rng_generator'):
+            model = state.model
+        elif hasattr(state.model, 'module') and hasattr(state.model.module, 'rng_generator'):
+            model = state.model.module
+        else:
+            raise ValueError('Model does not have an rng_generator')
+        assert isinstance(model, StableDiffusion)
+
+        if event == Event.INIT:
+            # Create the RNG generators
+            self.train_rng_generator = torch.Generator(device=state.device._device)
+            self.eval_rng_generator = torch.Generator(device=state.device._device)
+            # Set the seed
+            self.seed = state.rank_zero_seed + dist.get_global_rank()
+            self.train_rng_generator.manual_seed(self.seed)
+            self.eval_rng_generator.manual_seed(self.seed)
+            # Set the states if they exist
+            if self.train_rng_state is not None:
+                self.train_rng_generator.set_state(self.train_rng_state)
+            if self.eval_rng_state is not None:
+                self.eval_rng_generator.set_state(self.eval_rng_state)
+        elif event == Event.EVAL_START:
+            # Reset the eval rng generator to ensure the same randomness is used every eval epoch
+            self.eval_rng_generator = self.eval_rng_generator.manual_seed(self.seed)
+            # Set the model's rng generator to the eval rng generator
+            model.set_rng_generator(self.eval_rng_generator)
+        elif event == Event.EVAL_END:
+            # Set the model's rng generator to the train rng generator
+            model.set_rng_generator(self.train_rng_generator)
+
+    def state_dict(self) -> Dict[str, Any]:
+        state_dict = super().state_dict()
+        state_dict['train_rng_state'] = self.train_rng_generator.get_state()
+        state_dict['eval_rng_state'] = self.eval_rng_generator.get_state()
+        return state_dict
+
+    def load_state_dict(self, state: Dict[str, Any], strict: bool = False):
+        self.train_rng_state = state['train_rng_state']
+        self.eval_rng_state = state['eval_rng_state']


### PR DESCRIPTION
As is, during eval we get different randomness every time we run eval. This leads to eval loss curves having extra noise. This PR adds an algorithm to pin the eval randomness such that we get the same randomness per sample for every eval, provided number of devices doesn't change.

A comparison of an eval loss curve with/without controlling the randomness over a few resumptions:
<img width="676" alt="Screenshot 2024-01-19 at 4 07 16 PM" src="https://github.com/mosaicml/diffusion/assets/83666378/dc28a672-cf4a-41b4-9b1c-b871f9353184">

To use it, add the algorithm to the `algorithms` section of the yaml
<img width="513" alt="Screenshot 2024-01-19 at 4 09 23 PM" src="https://github.com/mosaicml/diffusion/assets/83666378/699d8dfb-0f1b-4721-8028-1dffda849f6b">
