### PR TITLE
Add image only dataset + script to add captions generated by LLaVA to a streaming dataset

### DIFF
--- a/diffusion/datasets/image.py
+++ b/diffusion/datasets/image.py
@@ -1,0 +1,134 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming Image dataset."""
+
+import logging
+from io import BytesIO
+from typing import Callable, Dict, List, Optional, Sequence, Union
+
+from PIL import Image
+from streaming import Stream, StreamingDataset
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+log = logging.getLogger(__name__)
+
+# Disable PIL max image size limit
+Image.MAX_IMAGE_PIXELS = None
+
+
+class StreamingImageDataset(StreamingDataset):
+    """Streaming dataset for images.
+
+    Args:
+        streams (Sequence[Stream], optional): One or more Streams to stream/cache samples from.
+            ``StreamingImageCaptionDataset`` uses either ``streams`` or ``remote``/``local``. Default:``None``.
+        remote (str, optional): Remote directory (S3 or local filesystem) where dataset is stored. Default: ``None``.
+        local (str, optional): Local filesystem directory where dataset is cached during operation. Default: ``None``.
+        transform (Callable, optional): The transforms to apply to the image. Default: ``None``.
+        image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
+
+        **streaming_kwargs: Additional arguments to pass in the construction of the StreamingDataloader
+    """
+
+    def __init__(
+        self,
+        streams: Optional[Sequence[Stream]] = None,
+        remote: Optional[str] = None,
+        local: Optional[str] = None,
+        transform: Optional[Callable] = None,
+        image_key: str = 'image',
+        **streaming_kwargs,
+    ) -> None:
+
+        # Set defaults for vision-friendly streaming args.
+        streaming_kwargs.setdefault('shuffle_block_size', 1 << 18)
+        streaming_kwargs.setdefault('shuffle_algo', 'py1s')
+
+        super().__init__(
+            streams=streams,
+            remote=remote,
+            local=local,
+            **streaming_kwargs,
+        )
+
+        self.transform = transform
+        self.image_key = image_key
+
+    def __getitem__(self, index):
+        sample = super().__getitem__(index)
+        # Image
+        img = sample[self.image_key]
+        if not isinstance(img, Image.Image):
+            img = Image.open(BytesIO(sample[self.image_key]))
+        if img.mode != 'RGB':
+            img = img.convert('RGB')
+        # Image transforms
+        if self.transform is not None:
+            img = self.transform(img)
+        return {self.image_key: img}
+
+
+def build_streaming_image_dataloader(
+    remote: Union[str, List],
+    local: Union[str, List],
+    batch_size: int,
+    transform: Optional[List[Callable]] = None,
+    image_key: str = 'image',
+    streaming_kwargs: Optional[Dict] = None,
+    dataloader_kwargs: Optional[Dict] = None,
+):
+    """Builds a streaming LAION dataloader.
+
+    Args:
+        remote (str, Sequence[str]): One or more remote directories (S3 or local filesystem) where dataset is stored.
+        local (str, Sequence[str]): One or more local filesystem directories where dataset is cached during operation.
+        batch_size (int): The batch size to use for both the ``StreamingDataset`` and ``DataLoader``.
+        transform (Optional[Callable]): The transforms to apply to the image. Default: ``None``.
+        image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
+        streaming_kwargs (dict, optional): Additional arguments to pass to the ``StreamingDataset``. Default: ``None``.
+        dataloader_kwargs (dict, optional): Additional arguments to pass to the ``DataLoader``. Default: ``None``.
+    """
+    # Handle ``None`` kwargs
+    if streaming_kwargs is None:
+        streaming_kwargs = {}
+    if dataloader_kwargs is None:
+        dataloader_kwargs = {}
+
+    # Check types for remote and local
+    if isinstance(remote, str) and isinstance(local, str):
+        remote, local = [remote], [local]
+    elif isinstance(remote, Sequence) and isinstance(local, Sequence):
+        if len(remote) != len(local):
+            ValueError(
+                f'remote and local Sequences must be the same length, got lengths {len(remote)} and {len(local)}')
+    else:
+        ValueError(f'remote and local must be both Strings or Sequences, got types {type(remote)} and {type(local)}.')
+
+    # Create a Stream for each (remote, local) pair
+    streams = []
+    for r, l in zip(remote, local):
+        streams.append(Stream(remote=r, local=l))
+
+    if transform is None:
+        transform = [transforms.ToTensor()]
+    transform = transforms.Compose(transform)
+    assert isinstance(transform, Callable)
+
+    dataset = StreamingImageDataset(
+        streams=streams,
+        transform=transform,
+        image_key=image_key,
+        batch_size=batch_size,
+        **streaming_kwargs,
+    )
+
+    dataloader = DataLoader(
+        dataset=dataset,
+        batch_size=batch_size,
+        sampler=None,
+        **dataloader_kwargs,
+    )
+
+    return dataloader

--- a/diffusion/datasets/image.py
+++ b/diffusion/datasets/image.py
@@ -68,7 +68,7 @@ class StreamingImageDataset(StreamingDataset):
         sample = super().__getitem__(index)
         # Image
         if not isinstance(sample[self.image_key], Image.Image):
-            img = Image.open(BytesIO(sample[self.image_key])).copy()
+            img = Image.open(BytesIO(sample[self.image_key]))
         else:
             img = sample[self.image_key].copy()
         if img.mode != 'RGB':
@@ -117,10 +117,11 @@ def build_streaming_image_dataloader(
         remote, local = [remote], [local]
     elif isinstance(remote, Sequence) and isinstance(local, Sequence):
         if len(remote) != len(local):
-            ValueError(
+            raise ValueError(
                 f'remote and local Sequences must be the same length, got lengths {len(remote)} and {len(local)}')
     else:
-        ValueError(f'remote and local must be both Strings or Sequences, got types {type(remote)} and {type(local)}.')
+        raise ValueError(
+            f'remote and local must be both Strings or Sequences, got types {type(remote)} and {type(local)}.')
 
     # Create a Stream for each (remote, local) pair
     streams = []

--- a/diffusion/datasets/image.py
+++ b/diffusion/datasets/image.py
@@ -77,9 +77,9 @@ class StreamingImageDataset(StreamingDataset):
         if self.transform is not None:
             img = self.transform(img)
         # Make the output
-        if self.image_output_key != self.image_key and self.image_output_key in sample:
-            raise ValueError(f'Output key {self.image_output_key} already exists in the sample.')
         if self.return_all_fields:
+            if self.image_output_key != self.image_key and self.image_output_key in sample:
+                raise ValueError(f'Output key {self.image_output_key} already exists in the sample.')
             output = {**sample, self.image_output_key: img}
         else:
             output = {self.image_output_key: img}

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -1,0 +1,221 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Script to LLaVA caption an image dataset."""
+
+import argparse
+import os
+import time
+
+import torch
+from huggingface_hub import snapshot_download
+from torchvision import transforms
+
+try:
+    from llava.constants import DEFAULT_IMAGE_TOKEN  # type: ignore
+    from llava.constants import DEFAULT_IM_END_TOKEN, DEFAULT_IM_START_TOKEN, IMAGE_TOKEN_INDEX  # type: ignore
+    from llava.conversation import SeparatorStyle, conv_templates  # type: ignore
+    from llava.mm_utils import get_model_name_from_path, tokenizer_image_token  # type: ignore
+    from llava.model.builder import load_pretrained_model  # type: ignore
+    from llava.utils import disable_torch_init  # type: ignore
+except ImportError:
+    raise ImportError(
+        'LLaVA is not installed. Please install it with `pip install llava@git+https://github.com/haotian-liu/LLaVA.git`'
+    )
+
+from PIL import Image, ImageOps
+from streaming import Stream
+from streaming.base import MDSWriter
+
+from diffusion.datasets.image import StreamingImageDataset
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--remotes', nargs='+', help='List of remotes to use for the dataset.')
+parser.add_argument('--locals', nargs='+', help='List of local directories to use for the dataset.')
+parser.add_argument('--output', help='Output path for the filtered dataset.')
+parser.add_argument('--output_caption_key', type=str, default='llava_caption', help='Dataset output caption key.')
+parser.add_argument('--image_key', type=str, default='image', help='Dataset image key.')
+parser.add_argument('--image_output_key', type=str, default='image_output', help='Dataset image output key.')
+parser.add_argument('--batch_size', type=int, default=1, help='Batch size for the LLaVA model.')
+parser.add_argument('--height', type=int, default=512, help='Height of the image.')
+parser.add_argument('--width', type=int, default=512, help='Width of the image.')
+parser.add_argument('--model_name', type=str, default='liuhaotian/llava-v1.6-vicuna-13b', help='LLaVA model to use.')
+parser.add_argument('--llava_prompt',
+                    type=str,
+                    default='Describe this image and its style in a very detailed manner.',
+                    help='Prompt to use for LLaVA.')
+parser.add_argument('--max_tokens', type=int, default=1024, help='Maximum tokens to generate.')
+parser.add_argument('--compile', action='store_true', help='Compile the model.')
+args = parser.parse_args()
+
+
+def make_dataset(remote: str, local: str, image_key: str = 'image', image_output_key: str = 'image_output'):
+    """Make a streaming image dataset."""
+    streams = []
+    for r, l in zip([remote], [local]):
+        streams.append(Stream(remote=r, local=l))
+
+    transform = transforms.Compose([])
+    dataset = StreamingImageDataset(
+        streams=streams,
+        image_key=image_key,
+        image_output_key=image_output_key,
+        transform=transform,
+        shuffle=False,
+        return_all_fields=True,
+    )
+    return dataset
+
+
+class LLaVACaptioner:
+    """LLaVA captioner class."""
+
+    def __init__(self, model_name: str = 'liuhaotian/llava-v1.5-13b', max_tokens: int = 512, compile: bool = False):
+        self.model_name = model_name
+        self.tokenizer, self.model, self.image_processor, self.context_len = self.load_llava()
+        if compile:
+            self.model = torch.compile(self.model)
+        self.conv_mode = 'llava_v1'
+        self.max_tokens = max_tokens
+        self.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+    def to(self, device: torch.device):
+        self.device = device
+        self.model.to(device)
+        return self
+
+    def load_llava(self):
+        """Loads the llava model."""
+        # Download the llava model if it isn't there already.
+        snapshot_download(
+            repo_id=self.model_name,
+            local_dir='/tmp/llava',
+            local_dir_use_symlinks=False,
+        )
+        disable_torch_init()
+        model_path = os.path.expanduser('/tmp/llava')
+        model_name = get_model_name_from_path(model_path)
+        return load_pretrained_model(model_path, None, model_name)
+
+    def add_image_tokens(self, prompt: str) -> str:
+        if self.model.config.mm_use_im_start_end:
+            prompt = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + '\n' + prompt
+        else:
+            prompt = DEFAULT_IMAGE_TOKEN + '\n' + prompt
+        return prompt
+
+    def tokenize(self, prompt: str) -> torch.Tensor:
+        input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors='pt')
+        return input_ids.unsqueeze(0).to(self.device)
+
+    def get_outputs(self, image_batch: torch.Tensor, prompt: str) -> list:
+        """Get the output from llava."""
+        # Format the prompt
+        prompt = self.add_image_tokens(prompt)
+        conv = conv_templates[self.conv_mode].copy()
+        conv.append_message(conv.roles[0], prompt)
+        conv.append_message(conv.roles[1], None)
+        prompt = conv.get_prompt()
+        input_ids = self.tokenize(prompt)
+        # Prep the image
+        image_batch = image_batch.to(self.device)  # In range (0, 1)
+        # repeat the prompt along the batch dimension for each image
+        input_ids = input_ids.repeat(image_batch.shape[0], 1)
+        # Prep the image inputs
+        image_tensor = self.image_processor.preprocess(image_batch, do_rescale=False,
+                                                       return_tensors='pt')['pixel_values']
+        # Forward through the model
+        with torch.inference_mode():
+            output_ids = self.model.generate(input_ids,
+                                             images=image_tensor.half().to(device),
+                                             do_sample=True,
+                                             temperature=0.2,
+                                             top_p=None,
+                                             num_beams=1,
+                                             max_new_tokens=self.max_tokens,
+                                             use_cache=True)
+        # Postprocess outputs
+        decoded_output = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+        outputs = [o.strip() for o in decoded_output]
+        return outputs
+
+
+def resize_and_pad(image, target_width, target_height):
+    """Resize and pad an image to the target size while maintaining aspect ratio.
+
+    Args:
+    - image (PIL Image): The image to be resized and padded.
+    - target_width (int): The target width.
+    - target_height (int): The target height.
+
+    Returns:
+    - PIL Image: The resized and padded image.
+    """
+    # Calculate the aspect ratio and find the smaller dimension.
+    original_width, original_height = image.size
+    aspect_ratio = original_width / original_height
+
+    # Resize such that the smaller dimension fits the corresponding target dimension.
+    if original_width < original_height:  # Width is smaller, match width
+        resize_width = target_width
+        resize_height = round(resize_width / aspect_ratio)
+    elif original_width > original_height:  # Height is smaller, match height
+        resize_height = target_height
+        resize_width = round(resize_height * aspect_ratio)
+    else:  # Image is square, match either dimension
+        resize_width = target_width
+        resize_height = target_height
+
+    resized_image = image.resize((resize_width, resize_height), Image.ANTIALIAS)
+
+    # Calculate padding
+    pad_width_left = (target_width - resize_width) // 2
+    pad_width_right = target_width - resize_width - pad_width_left
+
+    pad_height_top = (target_height - resize_height) // 2
+    pad_height_bottom = target_height - resize_height - pad_height_top
+
+    # Apply asymmetric padding if necessary
+    padded_image = ImageOps.expand(resized_image,
+                                   border=(pad_width_left, pad_height_top, pad_width_right, pad_height_bottom),
+                                   fill=0)
+
+    return padded_image
+
+
+if __name__ == '__main__':
+    dataset = make_dataset(args.remote, args.local, image_key=args.image_key, image_output_key=args.image_output_key)
+    dataset_len = len(dataset)
+    to_tensor = transforms.ToTensor()
+
+    # Device should be first gpu if available, else cpu
+    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    captioner = LLaVACaptioner(model_name=args.model_name, max_tokens=args.max_tokens, compile=args.compile).to(device)
+
+    reader = dataset.shards[0]
+    columns = dict(zip(reader.column_names, reader.column_encodings))
+    columns[args.output_caption_key] = 'str'
+
+    start = 0
+    with MDSWriter(out=args.output, columns=columns) as out:
+        for sample_id in range(0, len(dataset), args.batch_size):
+            images = [dataset[i][args.image_output_key] for i in range(sample_id, sample_id + args.batch_size)]
+            image_batch = [resize_and_pad(image, args.width, args.height) for image in images]
+            image_batch = [to_tensor(image) for image in image_batch]
+            image_batch = torch.stack(image_batch)
+            if sample_id == args.batch_size:
+                start = time.time()
+            outputs = captioner.get_outputs(image_batch, args.llava_prompt)
+            for output_id, output in enumerate(outputs):
+                new_sample = dataset[sample_id + output_id]
+                new_sample[args.output_caption_key] = output
+                out.write(new_sample)
+                print('*' * 120)
+                print(output)
+                print('*' * 120)
+            if sample_id >= args.batch_size:
+                current_time = time.time()
+                print('-' * 120)
+                print('Sample ID:', sample_id)
+                print('Time per image:', (current_time - start) / (sample_id))
+                print('-' * 120)

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -292,6 +292,8 @@ def main(args: Namespace) -> None:
         # If end has not been specified, each rank processes all the data it has been given.
         start_idx = args.start
         end_idx = dataset_len
+    if not args.wandb_disabled:
+        wandb.log({'start_idx': start_idx, 'end_idx': end_idx, 'dataset_len': dataset_len})
     # Each rank needs it's own output
     output_dir = args.output + f'/{dist.get_global_rank()}'
     # Process each subset

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -298,7 +298,7 @@ def main(args: Namespace) -> None:
             outputs = captioner.get_outputs(image_batch, args.llava_prompt)
             sample_time = time.time() - sample_time
             for output_id, output in enumerate(outputs):
-                if sample_id + output_id <= end_idx:
+                if sample_id + output_id < end_idx:
                     new_sample = dataset[sample_id + output_id]
                     new_sample[args.output_caption_key] = output
                     out.write(new_sample)

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -330,6 +330,7 @@ def main(args: Namespace) -> None:
                     'avg. time per sample (s)': time_per_sample,
                     'est. time remaining (s)': est_time_remaining
                 })
+            dist.barrier()
 
 
 if __name__ == '__main__':

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -30,8 +30,8 @@ from streaming.base import MDSWriter
 from diffusion.datasets.image import StreamingImageDataset
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--remotes', nargs='+', help='List of remotes to use for the dataset.')
-parser.add_argument('--locals', nargs='+', help='List of local directories to use for the dataset.')
+parser.add_argument('--remote', type=str, help='Remote to use for the dataset.')
+parser.add_argument('--local', type=str, help='Local directory to use for the dataset.')
 parser.add_argument('--output', help='Output path for the filtered dataset.')
 parser.add_argument('--output_caption_key', type=str, default='llava_caption', help='Dataset output caption key.')
 parser.add_argument('--image_key', type=str, default='image', help='Dataset image key.')

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -47,6 +47,8 @@ parser.add_argument('--llava_prompt',
                     help='Prompt to use for LLaVA.')
 parser.add_argument('--max_tokens', type=int, default=1024, help='Maximum tokens to generate.')
 parser.add_argument('--compile', action='store_true', help='Compile the model.')
+parser.add_argument('--start', type=int, default=0, help='Start index for the dataset.')
+parser.add_argument('--end', type=int, default=None, help='Optional end index for the dataset.')
 args = parser.parse_args()
 
 
@@ -208,8 +210,9 @@ if __name__ == '__main__':
     columns[args.output_caption_key] = 'str'
 
     start = time.time()
+    end = args.end if args.end is not None else dataset_len
     with MDSWriter(out=args.output, columns=columns) as out:
-        for sample_id in tqdm(range(0, dataset_len, args.batch_size)):
+        for sample_id in tqdm(range(args.start, end, args.batch_size)):
             images = [dataset[i][args.image_output_key] for i in range(sample_id, sample_id + args.batch_size)]
             image_batch = batch_images(images, width=args.width, height=args.height)
             if sample_id == args.batch_size:

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -216,6 +216,6 @@ if __name__ == '__main__':
             if sample_id >= args.batch_size:
                 current_time = time.time()
                 print('-' * 120)
-                print('Sample ID:', sample_id)
+                print('Sample ID:', sample_id, "of", dataset_len)
                 print('Time per image:', (current_time - start) / (sample_id))
                 print('-' * 120)

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -207,6 +207,7 @@ if __name__ == '__main__':
     columns = dict(zip(reader.column_names, reader.column_encodings))
     columns[args.output_caption_key] = 'str'
 
+    start = time.time()
     with MDSWriter(out=args.output, columns=columns) as out:
         for sample_id in tqdm(range(0, dataset_len, args.batch_size)):
             images = [dataset[i][args.image_output_key] for i in range(sample_id, sample_id + args.batch_size)]
@@ -218,3 +219,12 @@ if __name__ == '__main__':
                 new_sample = dataset[sample_id + output_id]
                 new_sample[args.output_caption_key] = output
                 out.write(new_sample)
+            print('*' * 80)
+            print(f'Processed {sample_id + args.batch_size} samples in {time.time() - start:.2f} seconds.')
+            print(f'Average time per sample: {(time.time() - start) / (sample_id + args.batch_size):.2f} seconds.')
+            print(
+                f'Est. time remaining: {((dataset_len - sample_id) * (time.time() - start) / (sample_id + args.batch_size)) / 60:.2f} minutes'
+            )
+            print('Output:')
+            print(outputs[0])
+            print('*' * 80)

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -298,9 +298,10 @@ def main(args: Namespace) -> None:
             outputs = captioner.get_outputs(image_batch, args.llava_prompt)
             sample_time = time.time() - sample_time
             for output_id, output in enumerate(outputs):
-                new_sample = dataset[sample_id + output_id]
-                new_sample[args.output_caption_key] = output
-                out.write(new_sample)
+                if sample_id + output_id <= end_idx:
+                    new_sample = dataset[sample_id + output_id]
+                    new_sample[args.output_caption_key] = output
+                    out.write(new_sample)
             if not args.wandb_disabled:
                 if sample_id == start_idx:
                     # On the first batch, log sample images and captions for verification.

--- a/scripts/batched-llava-caption.py
+++ b/scripts/batched-llava-caption.py
@@ -283,7 +283,7 @@ def main(args: Namespace) -> None:
     end = args.end if args.end is not None else dataset_len
     samples_per_rank, remainder = divmod(end - args.start, dist.get_world_size())
     # Need to distribute the remainder across the ranks. Give each rank up to remainder one extra sample.
-    start_idx = args.start + dist.get_local_rank() * (samples_per_rank + min(remainder, dist.get_local_rank()))
+    start_idx = args.start + dist.get_local_rank() * samples_per_rank + min(remainder, dist.get_local_rank())
     end_idx = start_idx + samples_per_rank
     if dist.get_local_rank() < remainder:
         end_idx += 1


### PR DESCRIPTION
The image only dataset exists to allow captioning datasets that do not already have captions in them, and to provide the option to return all fields as part of sampling. 

The captioning script can be run on a multi-gpu instance like so:
```
composer scripts/batched-llava-caption.py --remote REMOTE_FOR_ORIGINAL_DATASET --local LOCAL_SHARDS_DIR --output REMOTE_FOR_NEW_DATASET
```