### PR TITLE
make local paths optional

### DIFF
--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -224,10 +224,10 @@ def build_streaming_image_caption_dataloader(
 
     if isinstance(remote, str):
         remote = [remote]
-
+    if isinstance(local, str):
+        local = [local]
     if not local:
         local = [_make_default_local_path(r) for r in remote]
-
     if isinstance(remote, Sequence) and isinstance(local, Sequence):
         if len(remote) != len(local):
             ValueError(

--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -3,21 +3,21 @@
 
 """Streaming Image-Caption dataset."""
 
-from pathlib import Path
 import logging
 import random
 from io import BytesIO
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import torch
-from PIL import Image
 import transformers
+from PIL import Image
 from streaming import Stream, StreamingDataset
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from diffusion.models.text_encoder import MultiTokenizer
 from diffusion.datasets.laion.transforms import LargestCenterSquare, RandomCropAspectRatioTransorm, RandomCropSquare
+from diffusion.models.text_encoder import MultiTokenizer
 
 log = logging.getLogger(__name__)
 
@@ -29,8 +29,8 @@ class StreamingImageCaptionDataset(StreamingDataset):
     """Streaming dataset for image-caption pairs.
 
     Args:
-        tokenizer (transformers.PreTrainedTokenizer, MultiTokenizer): Tokenizer used for text input. 
-            Should be the same tokenizer passed to the model being trained. 
+        tokenizer (transformers.PreTrainedTokenizer, MultiTokenizer): Tokenizer used for text input.
+            Should be the same tokenizer passed to the model being trained.
             Can be accessed with model.tokenizer.
         streams (Sequence[Stream], optional): One or more Streams to stream/cache samples from.
             ``StreamingImageCaptionDataset`` uses either ``streams`` or ``remote``/``local``. Default:``None``.
@@ -187,8 +187,8 @@ def build_streaming_image_caption_dataloader(
         remote (str, Sequence[str]): One or more remote directories (S3 or local filesystem) where dataset is stored.
         local (str, Sequence[str]): One or more local filesystem directories where dataset is cached during operation.
         batch_size (int): The batch size to use for both the ``StreamingDataset`` and ``DataLoader``.
-        tokenizer (transformers.PreTrainedTokenizer, MultiTokenizer): Tokenizer used for text input. 
-            Should be the same tokenizer passed to the model being trained. 
+        tokenizer (transformers.PreTrainedTokenizer, MultiTokenizer): Tokenizer used for text input.
+            Should be the same tokenizer passed to the model being trained.
             Can be accessed with model.tokenizer.
         caption_drop_prob (float): The probability of dropping a caption. Default: ``0.0``.
         microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL. Default: ``0.0``.
@@ -218,10 +218,10 @@ def build_streaming_image_caption_dataloader(
         dataloader_kwargs = {}
 
     # Check types for remote and local
-    
+
     if isinstance(remote, str):
         remote = [remote]
-    
+
     if not local:
         local = [_make_default_local_path(r) for r in remote]
 
@@ -235,7 +235,7 @@ def build_streaming_image_caption_dataloader(
     # Create a Stream for each (remote, local) pair
     streams = []
     for r, l in zip(remote, local):
-            streams.append(Stream(remote=r, local=l))
+        streams.append(Stream(remote=r, local=l))
 
     # Set the crop to apply
     if crop_type == 'square':
@@ -279,5 +279,4 @@ def build_streaming_image_caption_dataloader(
 
 
 def _make_default_local_path(remote_path):
-    return str(Path(*["/tmp"] + list(Path(remote_path).parts[1:])))
-    
+    return str(Path(*['/tmp'] + list(Path(remote_path).parts[1:])))

--- a/diffusion/datasets/synthetic_image_caption.py
+++ b/diffusion/datasets/synthetic_image_caption.py
@@ -16,12 +16,14 @@ class SyntheticImageCaptionDataset(Dataset):
     Args:
         image_size (int): Size of the synthetic images. Default: ``512``.
         caption_length (int): Length of the synthetic captions. Default: ``77``.
+        tokenizer: dummy parameter to mimic api of real dataset. 
         sdxl (bool): Whether or not to generate synthetic data for SDXL. Default: ``False``.
     """
 
-    def __init__(self, image_size: int = 512, caption_length: int = 77, sdxl: bool = False):
+    def __init__(self, tokenizer=None, image_size: int = 512, caption_length: int = 77, sdxl: bool = False):
 
         super().__init__()
+        self.tokenizer = tokenizer
         self.image_size = image_size
         self.sdxl = sdxl
         self.caption_shape = (2, caption_length) if self.sdxl else (caption_length,)
@@ -42,6 +44,7 @@ class SyntheticImageCaptionDataset(Dataset):
 
 def build_synthetic_image_caption_dataloader(
     batch_size: int,
+    tokenizer = None,
     image_size: int = 512,
     caption_length: int = 77,
     sdxl: bool = False,
@@ -60,6 +63,7 @@ def build_synthetic_image_caption_dataloader(
         dataloader_kwargs = {}
 
     dataset = SyntheticImageCaptionDataset(
+        tokenizer=tokenizer,
         image_size=image_size,
         caption_length=caption_length,
         sdxl=sdxl,

--- a/diffusion/datasets/synthetic_image_caption.py
+++ b/diffusion/datasets/synthetic_image_caption.py
@@ -16,7 +16,7 @@ class SyntheticImageCaptionDataset(Dataset):
     Args:
         image_size (int): Size of the synthetic images. Default: ``512``.
         caption_length (int): Length of the synthetic captions. Default: ``77``.
-        tokenizer: dummy parameter to mimic api of real dataset. 
+        tokenizer: dummy parameter to mimic api of real dataset. Default: ``None``.
         sdxl (bool): Whether or not to generate synthetic data for SDXL. Default: ``False``.
     """
 
@@ -44,7 +44,7 @@ class SyntheticImageCaptionDataset(Dataset):
 
 def build_synthetic_image_caption_dataloader(
     batch_size: int,
-    tokenizer = None,
+    tokenizer=None,
     image_size: int = 512,
     caption_length: int = 77,
     sdxl: bool = False,
@@ -54,6 +54,7 @@ def build_synthetic_image_caption_dataloader(
 
     Args:
         batch_size (int): Batch size for the dataloader.
+        tokenizer: dummy parameter to mimic api of real dataset. Default: ``None``.
         image_size (int): Size of the synthetic images. Default: ``512``.
         caption_length (int): Length of the synthetic captions. Default: ``77``.
         sdxl (bool): Whether or not to generate synthetic data for SDXL. Default: ``False``.

--- a/diffusion/evaluate.py
+++ b/diffusion/evaluate.py
@@ -35,9 +35,7 @@ def evaluate(config: DictConfig) -> None:
 
     # The dataloader to use for evaluation
     if tokenizer:
-        eval_dataloader = hydra.utils.instantiate(
-                                        config.eval_dataloader,
-                                        tokenizer=tokenizer)
+        eval_dataloader = hydra.utils.instantiate(config.eval_dataloader, tokenizer=tokenizer)
 
     else:
         eval_dataloader: DataLoader = hydra.utils.instantiate(config.eval_dataloader)

--- a/diffusion/evaluate.py
+++ b/diffusion/evaluate.py
@@ -31,8 +31,16 @@ def evaluate(config: DictConfig) -> None:
     # The model to evaluate
     model: ComposerModel = hydra.utils.instantiate(config.model)
 
+    tokenizer = model.tokenizer if hasattr(model, 'tokenizer') else None
+
     # The dataloader to use for evaluation
-    eval_dataloader: DataLoader = hydra.utils.instantiate(config.eval_dataloader)
+    if tokenizer:
+        eval_dataloader = hydra.utils.instantiate(
+                                        config.eval_dataloader,
+                                        tokenizer=tokenizer)
+
+    else:
+        eval_dataloader: DataLoader = hydra.utils.instantiate(config.eval_dataloader)
 
     # The CLIPScores metric to use for evaluation
     clip_metric: CLIPScore = hydra.utils.instantiate(config.clip_metric)

--- a/diffusion/train.py
+++ b/diffusion/train.py
@@ -73,6 +73,7 @@ def train(config: DictConfig) -> None:
     # upstream composer changes that could make this easier.
     train_dataloader: Union[Iterable, DataSpec, Dict[str, Any]] = hydra.utils.instantiate(
         config.dataset.train_dataset,
+        tokenizer=model.tokenizer,
         batch_size=config.dataset.train_batch_size // dist.get_world_size(),
     )
     # Need to sleep for a bit to avoid dataloader crash
@@ -88,7 +89,8 @@ def train(config: DictConfig) -> None:
             print(OmegaConf.to_yaml(eval_conf))
             eval_dataloader = hydra.utils.instantiate(
                 eval_conf.eval_dataset,
-                config.dataset.eval_batch_size // dist.get_world_size(),
+                tokenizer=model.tokenizer,
+                batch_size=config.dataset.eval_batch_size // dist.get_world_size(),
             )
             evaluator = hydra.utils.instantiate(eval_conf.evaluator, dataloader=eval_dataloader)
             # Need to sleep for a bit to avoid dataloader crash
@@ -99,6 +101,7 @@ def train(config: DictConfig) -> None:
 
     else:
         eval_set = hydra.utils.instantiate(config.dataset.eval_dataset,
+                                           tokenizer=model.tokenizer,
                                            batch_size=config.dataset.eval_batch_size // dist.get_world_size())
         # Need to sleep for a bit to avoid dataloader crash
         time.sleep(10)

--- a/diffusion/train.py
+++ b/diffusion/train.py
@@ -83,7 +83,7 @@ def train(config: DictConfig) -> None:
         train_dataloader: Union[Iterable, DataSpec, Dict[str, Any]] = hydra.utils.instantiate(
             config.dataset.train_dataset,
             batch_size=config.dataset.train_batch_size // dist.get_world_size(),
-        ) 
+        )
     # Need to sleep for a bit to avoid dataloader crash
     time.sleep(10)
 
@@ -117,11 +117,11 @@ def train(config: DictConfig) -> None:
     else:
         if tokenizer:
             eval_set = hydra.utils.instantiate(config.dataset.eval_dataset,
-                                            tokenizer=model.tokenizer,
-                                            batch_size=config.dataset.eval_batch_size // dist.get_world_size())
+                                               tokenizer=model.tokenizer,
+                                               batch_size=config.dataset.eval_batch_size // dist.get_world_size())
         else:
             eval_set = hydra.utils.instantiate(config.dataset.eval_dataset,
-                                batch_size=config.dataset.eval_batch_size // dist.get_world_size())
+                                               batch_size=config.dataset.eval_batch_size // dist.get_world_size())
 
         # Need to sleep for a bit to avoid dataloader crash
         time.sleep(10)

--- a/yamls/hydra-yamls/SDXL-base-1024.yaml
+++ b/yamls/hydra-yamls/SDXL-base-1024.yaml
@@ -28,9 +28,6 @@ dataset:
     _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
     remote:
       # Path to object store bucket(s)
-    local:
-      # Path to corresponding local dataset(s)
-    tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
     caption_drop_prob: 0.1
     caption_key: caption
     image_key: jpg
@@ -51,7 +48,6 @@ dataset:
   eval_dataset:
     _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
     remote:  # Path to object store bucket
-    local: # Path to local dataset cache
     resize_size: 1024
     prefetch_factor: 2
     num_workers: 8

--- a/yamls/hydra-yamls/SDXL-base-256.yaml
+++ b/yamls/hydra-yamls/SDXL-base-256.yaml
@@ -28,9 +28,6 @@ dataset:
     _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
     remote:
       # Path to object store bucket(s)
-    local:
-      # Path to corresponding local dataset(s)
-    tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
     caption_drop_prob: 0.1
     caption_key: caption
     image_key: jpg
@@ -50,7 +47,6 @@ dataset:
   eval_dataset:
     _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
     remote:  # Path to object store bucket
-    local: # Path to local dataset cache
     resize_size: 256
     prefetch_factor: 2
     num_workers: 8

--- a/yamls/hydra-yamls/SDXL-base-512.yaml
+++ b/yamls/hydra-yamls/SDXL-base-512.yaml
@@ -28,9 +28,6 @@ dataset:
     _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
     remote:
       # Path to object store bucket(s)
-    local:
-      # Path to corresponding local dataset(s)
-    tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
     caption_drop_prob: 0.1
     caption_key: caption
     image_key: jpg
@@ -50,7 +47,6 @@ dataset:
   eval_dataset:
     _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
     remote:  # Path to object store bucket
-    local: # Path to local dataset cache
     resize_size: 512
     prefetch_factor: 2
     num_workers: 8

--- a/yamls/hydra-yamls/train-custom-autoencoder.yaml
+++ b/yamls/hydra-yamls/train-custom-autoencoder.yaml
@@ -21,7 +21,6 @@ dataset:
     remote: # Path(s) to object store bucket for training data
     local: # Path(s) to local training dataset cache
     batch_size: ${batch_size}
-    tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
     caption_drop_prob: 0.1
     resize_size: ${image_size}
     image_key: image # Image key in the train dataset
@@ -43,7 +42,6 @@ dataset:
     local: # Path(s) to local eval dataset cache
     batch_size: ${batch_size}
     resize_size: ${image_size}
-    tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
     caption_drop_prob: 0.0
     image_key: image # Image key in the eval dataset
     caption_key: caption # Caption key in the eval dataset

--- a/yamls/hydra-yamls/train-diffusers-autoencoder.yaml
+++ b/yamls/hydra-yamls/train-diffusers-autoencoder.yaml
@@ -20,7 +20,6 @@ dataset:
     remote: # Path(s) to object store bucket for training data
     local: # Path(s) to local training dataset cache
     batch_size: ${batch_size}
-    tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
     caption_drop_prob: 0.1
     resize_size: ${image_size}
     image_key: image # Image key in the train dataset
@@ -42,7 +41,6 @@ dataset:
     local: # Path(s) to local eval dataset cache
     batch_size: ${batch_size}
     resize_size: ${image_size}
-    tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
     caption_drop_prob: 0.0
     image_key: image # Image key in the eval dataset
     caption_key: caption # Caption key in the eval dataset

--- a/yamls/mosaic-yamls/SDXL-base-1024.yaml
+++ b/yamls/mosaic-yamls/SDXL-base-1024.yaml
@@ -52,9 +52,6 @@ parameters:
       _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
       remote:
         # Path to object store bucket(s)
-      local:
-        # Path to corresponding local dataset(s)
-      tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
       caption_drop_prob: 0.1
       caption_key: caption
       image_key: jpg
@@ -75,7 +72,6 @@ parameters:
     eval_dataset:
       _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
       remote:  # Path to object store bucket
-      local: # Path to local dataset cache
       resize_size: 1024
       prefetch_factor: 2
       num_workers: 8

--- a/yamls/mosaic-yamls/SDXL-base-256.yaml
+++ b/yamls/mosaic-yamls/SDXL-base-256.yaml
@@ -52,9 +52,6 @@ parameters:
       _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
       remote:
         # Path to object store bucket(s)
-      local:
-        # Path to corresponding local dataset(s)
-      tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
       caption_drop_prob: 0.1
       caption_key: caption
       image_key: jpg
@@ -74,7 +71,6 @@ parameters:
     eval_dataset:
       _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
       remote:  # Path to object store bucket
-      local: # Path to local dataset cache
       resize_size: 256
       prefetch_factor: 2
       num_workers: 8

--- a/yamls/mosaic-yamls/SDXL-base-512.yaml
+++ b/yamls/mosaic-yamls/SDXL-base-512.yaml
@@ -16,6 +16,7 @@ integrations:
     project: # Insert wandb project name
     entity: # Insert wandb entity name
 env_variables:
+
 - key: HYDRA_FULL_ERROR
   value: '1' # Set to '0' to limit Hydra tracebacks
 command: |
@@ -52,9 +53,6 @@ parameters:
       _target_: diffusion.datasets.image_caption.build_streaming_image_caption_dataloader
       remote:
         # Path to object store bucket(s)
-      local:
-        # Path to corresponding local dataset(s)
-      tokenizer_name_or_path: stabilityai/stable-diffusion-xl-base-1.0
       caption_drop_prob: 0.1
       caption_key: caption
       image_key: jpg
@@ -74,7 +72,6 @@ parameters:
     eval_dataset:
       _target_: diffusion.datasets.coco.coco_captions.build_streaming_cocoval_dataloader
       remote:  # Path to object store bucket
-      local: # Path to local dataset cache
       resize_size: 512
       prefetch_factor: 2
       num_workers: 8

--- a/yamls/mosaic-yamls/train-custom-autoencoder.yaml
+++ b/yamls/mosaic-yamls/train-custom-autoencoder.yaml
@@ -44,7 +44,6 @@ parameters:
       remote: # Path(s) to object store bucket for training data
       local: # Path(s) to local training dataset cache
       batch_size: ${batch_size}
-      tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
       caption_drop_prob: 0.1
       resize_size: ${image_size}
       image_key: image # Image key in the train dataset
@@ -66,7 +65,6 @@ parameters:
       local: # Path(s) to local eval dataset cache
       batch_size: ${batch_size}
       resize_size: ${image_size}
-      tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
       caption_drop_prob: 0.0
       image_key: image # Image key in the eval dataset
       caption_key: caption # Caption key in the eval dataset

--- a/yamls/mosaic-yamls/train-diffusers-autoencoder.yaml
+++ b/yamls/mosaic-yamls/train-diffusers-autoencoder.yaml
@@ -43,7 +43,6 @@ parameters:
       remote: # Path(s) to object store bucket for training data
       local: # Path(s) to local training dataset cache
       batch_size: ${batch_size}
-      tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
       caption_drop_prob: 0.1
       resize_size: ${image_size}
       image_key: image # Image key in the train dataset
@@ -65,7 +64,6 @@ parameters:
       local: # Path(s) to local eval dataset cache
       batch_size: ${batch_size}
       resize_size: ${image_size}
-      tokenizer_name_or_path: stabilityai/stable-diffusion-2-base
       caption_drop_prob: 0.0
       image_key: image # Image key in the eval dataset
       caption_key: caption # Caption key in the eval dataset


### PR DESCRIPTION
This PR is aimed at cleaning up our yamls.  It makes local paths optional and passes tokenizers directly to datasets in `train.py` so the tokenizer string doesn't have to be specified in multiple places.

The default local path with be `/tmp/<streaming path>` the streaming path with have the cloud provide prefix removed (oci://, s3://, ect).

For models that don't have tokenizer attributes (autoencoders), no tokenizer will be used and raw text will be returned in the batch.

It doesn't currently support the old laion streaming dataset or coco_captions dataset.

tested with small sdxl-256 runs.