### PR TITLE
Add option to set per-channel mean, std. dev. of the autoencoder latents when training the UNet

### DIFF
--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -138,9 +138,9 @@ def stable_diffusion_2(
             unet_config['out_channels'] = vae.config['latent_channels']
         # Init the unet from the config
         unet = UNet2DConditionModel(**unet_config)
-    if type(latent_mean) is float:
+    if isinstance(latent_mean, float):
         latent_mean = (latent_mean,) * unet_config['in_channels']
-    if type(latent_std) is float:
+    if isinstance(latent_std, float):
         latent_std = (latent_std,) * unet_config['in_channels']
     assert isinstance(latent_mean, tuple) and isinstance(latent_std, tuple)
 
@@ -332,9 +332,9 @@ def stable_diffusion_xl(
                 layer = zero_module(layer)
         # Last conv block out projection
         unet.conv_out = zero_module(unet.conv_out)
-    if type(latent_mean) is float:
+    if isinstance(latent_mean, float):
         latent_mean = (latent_mean,) * unet_config['in_channels']
-    if type(latent_std) is float:
+    if isinstance(latent_std, float):
         latent_std = (latent_std,) * unet_config['in_channels']
     assert isinstance(latent_mean, tuple) and isinstance(latent_std, tuple)
 

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -114,7 +114,7 @@ def stable_diffusion_2(
     else:
         # Use a custom autoencoder
         vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=precision)
-        if latent_statistics is None and latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
+        if latent_statistics is None and (latent_mean == 'latent_statistics' or latent_std == 'latent_statistics'):
             raise ValueError(
                 'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
         if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':
@@ -293,7 +293,7 @@ def stable_diffusion_xl(
     else:
         # Use a custom autoencoder
         vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=precision)
-        if latent_statistics is None and latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
+        if latent_statistics is None and (latent_mean == 'latent_statistics' or latent_std == 'latent_statistics'):
             raise ValueError(
                 'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
         if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -4,7 +4,6 @@
 """Constructors for diffusion models."""
 
 import logging
-import math
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -36,7 +35,8 @@ def stable_diffusion_2(
     autoencoder_path: Optional[str] = None,
     autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
     prediction_type: str = 'epsilon',
-    latent_scale: Union[float, str] = 0.18215,
+    latent_mean: Union[float, list, str] = 0.0,
+    latent_std: Union[float, list, str] = 5.489980785067252,
     offset_noise: Optional[float] = None,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
@@ -61,8 +61,12 @@ def stable_diffusion_2(
         autoencoder_local_path (optional, str): Path to autoencoder weights. Default: `/tmp/autoencoder_weights.pt`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
-        latent_scale (float, str): The scale of the autoencoder latents. Either a float for the scaling value,
-            or `'latent_statistics'` to try to use the value from the autoencoder checkpoint. Defaults to `0.18215`.
+        latent_mean (float, list, str): The mean of the autoencoder latents. Either a float for a single value,
+            a list of means, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `0.0`.
+        latent_std (float, list, str): The std. dev. of the autoencoder latents. Either a float for a single value,
+            a list of std_devs, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `1/0.18215`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
             [MeanSquaredError()].
         val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
@@ -77,10 +81,18 @@ def stable_diffusion_2(
         clip_qkv (float, optional): If not None, clip the qkv values to this value. Defaults to None.
         use_xformers (bool): Whether to use xformers for attention. Defaults to True.
     """
-    if isinstance(latent_scale, str):
-        latent_scale = latent_scale.lower()
-        if latent_scale != 'latent_statistics':
-            raise ValueError(f'Invalid latent scale {latent_scale}. Must be a float or "latent_statistics".')
+    if isinstance(latent_mean, str):
+        latent_mean = latent_mean.lower()
+        if latent_mean != 'latent_statistics':
+            raise ValueError(f'Invalid latent scale {latent_mean}. Must be a float or "latent_statistics".')
+    elif isinstance(latent_mean, (list, tuple)):
+        latent_mean = list(latent_mean)
+    if isinstance(latent_std, str):
+        latent_std = latent_std.lower()
+        if latent_std != 'latent_statistics':
+            raise ValueError(f'Invalid latent scale {latent_std}. Must be a float or "latent_statistics".')
+    elif isinstance(latent_std, (list, tuple)):
+        latent_std = list(latent_std)
 
     if train_metrics is None:
         train_metrics = [MeanSquaredError()]
@@ -94,7 +106,7 @@ def stable_diffusion_2(
 
     # Make the autoencoder
     if autoencoder_path is None:
-        if latent_scale == 'latent_statistics':
+        if latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
             raise ValueError('Cannot use tracked latent_statistics when using the pretrained vae.')
         # Use the pretrained vae
         downsample_factor = 8
@@ -102,29 +114,35 @@ def stable_diffusion_2(
     else:
         # Use a custom autoencoder
         vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=precision)
-        if latent_statistics is not None and latent_scale == 'latent_statistics':
-            assert isinstance(latent_statistics['global_mean'], float)
-            assert isinstance(latent_statistics['global_std'], float)
-            second_moment = latent_statistics['global_mean']**2 + latent_statistics['global_std']**2
-            latent_scale = 1 / math.sqrt(second_moment)
-        else:
+        if latent_statistics is None and latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
             raise ValueError(
                 'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
+        if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_mean = latent_statistics['latent_channel_means']
+        if isinstance(latent_std, str) and latent_std == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_std = latent_statistics['latent_channel_stds']
         downsample_factor = 2**(len(vae.config['channel_multipliers']) - 1)
 
     # Make the unet
+    unet_config = PretrainedConfig.get_config_dict(model_name, subfolder='unet')[0]
     if pretrained:
         unet = UNet2DConditionModel.from_pretrained(model_name, subfolder='unet')
         if isinstance(vae, AutoEncoder) and vae.config['latent_channels'] != 4:
             raise ValueError(f'Pretrained unet has 4 latent channels but the vae has {vae.latent_channels}.')
     else:
-        unet_config = PretrainedConfig.get_config_dict(model_name, subfolder='unet')[0]
         if isinstance(vae, AutoEncoder):
             # Adapt the unet config to account for differing number of latent channels if necessary
             unet_config['in_channels'] = vae.config['latent_channels']
             unet_config['out_channels'] = vae.config['latent_channels']
         # Init the unet from the config
         unet = UNet2DConditionModel(**unet_config)
+    if type(latent_mean) is float:
+        latent_mean = [latent_mean] * unet_config['in_channels']
+    if type(latent_std) is float:
+        latent_std = [latent_std] * unet_config['in_channels']
+    assert isinstance(latent_mean, list) and isinstance(latent_std, list)
 
     # Make the noise schedulers
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
@@ -146,7 +164,8 @@ def stable_diffusion_2(
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
-        latent_scale=latent_scale,
+        latent_mean=latent_mean,
+        latent_std=latent_std,
         downsample_factor=downsample_factor,
         offset_noise=offset_noise,
         train_metrics=train_metrics,
@@ -183,7 +202,8 @@ def stable_diffusion_xl(
     autoencoder_path: Optional[str] = None,
     autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
     prediction_type: str = 'epsilon',
-    latent_scale: Union[float, str] = 0.13025,
+    latent_mean: Union[float, list, str] = 0.0,
+    latent_std: Union[float, list, str] = 0.13025,
     offset_noise: Optional[float] = None,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
@@ -214,8 +234,12 @@ def stable_diffusion_xl(
         autoencoder_local_path (optional, str): Path to autoencoder weights. Default: `/tmp/autoencoder_weights.pt`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
-        latent_scale (float, str): The scale of the autoencoder latents. Either a float for the scaling value,
-            or `'latent_statistics'` to try to use the value from the autoencoder checkpoint. Defaults to `0.13025`.
+        latent_mean (float, list, str): The mean of the autoencoder latents. Either a float for a single value,
+            a list of means, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `0.0`.
+        latent_std (float, list, str): The std. dev. of the autoencoder latents. Either a float for a single value,
+            a list of std_devs, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `1/0.13025`.
         offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
             be used. Default `None`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
@@ -231,10 +255,19 @@ def stable_diffusion_xl(
             of training.
         use_xformers (bool): Whether to use xformers for attention. Defaults to True.
     """
-    if isinstance(latent_scale, str):
-        latent_scale = latent_scale.lower()
-        if latent_scale != 'latent_statistics':
-            raise ValueError(f'Invalid latent scale {latent_scale}. Must be a float or "latent_statistics".')
+    if isinstance(latent_mean, str):
+        latent_mean = latent_mean.lower()
+        if latent_mean != 'latent_statistics':
+            raise ValueError(f'Invalid latent scale {latent_mean}. Must be a float or "latent_statistics".')
+    if isinstance(latent_mean, (list, tuple)):
+        latent_mean = list(latent_mean)
+    if isinstance(latent_std, str):
+        latent_std = latent_std.lower()
+        if latent_std != 'latent_statistics':
+            raise ValueError(f'Invalid latent scale {latent_std}. Must be a float or "latent_statistics".')
+    if isinstance(latent_std, (list, tuple)):
+        latent_std = list(latent_std)
+
     if train_metrics is None:
         train_metrics = [MeanSquaredError()]
     if val_metrics is None:
@@ -247,7 +280,7 @@ def stable_diffusion_xl(
     precision = torch.float16 if encode_latents_in_fp16 else None
     # Make the autoencoder
     if autoencoder_path is None:
-        if latent_scale == 'latent_statistics':
+        if latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
             raise ValueError('Cannot use tracked latent_statistics when using the pretrained vae.')
         downsample_factor = 8
         # Use the pretrained vae
@@ -258,23 +291,24 @@ def stable_diffusion_xl(
     else:
         # Use a custom autoencoder
         vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=precision)
-        if latent_statistics is not None and latent_scale == 'latent_statistics':
-            assert isinstance(latent_statistics['global_mean'], float)
-            assert isinstance(latent_statistics['global_std'], float)
-            second_moment = latent_statistics['global_mean']**2 + latent_statistics['global_std']**2
-            latent_scale = 1 / math.sqrt(second_moment)
-        else:
+        if latent_statistics is None and latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
             raise ValueError(
                 'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
+        if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_mean = latent_statistics['latent_channel_means']
+        if isinstance(latent_std, str) and latent_std == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_std = latent_statistics['latent_channel_stds']
         downsample_factor = 2**(len(vae.config['channel_multipliers']) - 1)
 
     # Make the unet
+    unet_config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')[0]
     if pretrained:
         unet = UNet2DConditionModel.from_pretrained(unet_model_name, subfolder='unet')
         if isinstance(vae, AutoEncoder) and vae.config['latent_channels'] != 4:
             raise ValueError(f'Pretrained unet has 4 latent channels but the vae has {vae.latent_channels}.')
     else:
-        unet_config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')[0]
         if isinstance(vae, AutoEncoder):
             # Adapt the unet config to account for differing number of latent channels if necessary
             unet_config['in_channels'] = vae.config['latent_channels']
@@ -292,6 +326,11 @@ def stable_diffusion_xl(
                 layer = zero_module(layer)
         # Last conv block out projection
         unet.conv_out = zero_module(unet.conv_out)
+    if type(latent_mean) is float:
+        latent_mean = [latent_mean] * unet_config['in_channels']
+    if type(latent_std) is float:
+        latent_std = [latent_std] * unet_config['in_channels']
+    assert isinstance(latent_mean, list) and isinstance(latent_std, list)
 
     # Make the noise schedulers
     noise_scheduler = DDPMScheduler.from_pretrained(model_name, subfolder='scheduler')
@@ -315,7 +354,8 @@ def stable_diffusion_xl(
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
-        latent_scale=latent_scale,
+        latent_mean=latent_mean,
+        latent_std=latent_std,
         downsample_factor=downsample_factor,
         offset_noise=offset_noise,
         train_metrics=train_metrics,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -206,7 +206,7 @@ def stable_diffusion_xl(
     autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
     prediction_type: str = 'epsilon',
     latent_mean: Union[float, Tuple, str] = 0.0,
-    latent_std: Union[float, Tuple, str] = 0.13025,
+    latent_std: Union[float, Tuple, str] = 7.67754318618,
     offset_noise: Optional[float] = None,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -3,7 +3,7 @@
 
 """Diffusion models."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -39,10 +39,10 @@ class StableDiffusion(ComposerModel):
         loss_fn (torch.nn.Module): torch loss function. Default: `F.mse_loss`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
-        latent_mean (Optional[list[float]]): The mean of the latent space. If not specified, defaults to
-            4 * [0]. Default: `None`.
-        latent_std (Optional[list[float]]): The standard deviation of the latent space. If not specified,
-            defaults to 4 * [1/0.13025] for SDXL, or 4 * [1/0.18215] for non-SDXL. Default: `None`.
+        latent_mean (Optional[tuple[float]]): The means of the latent space. If not specified, defaults to
+            4 * (0.0,). Default: `None`.
+        latent_std (Optional[tuple[float]]): The standard deviations of the latent space. If not specified,
+            defaults to 4 * (1/0.13025,) for SDXL, or 4 * (1/0.18215,) for non-SDXL. Default: `None`.
         downsample_factor (int): The factor by which the image is downsampled by the autoencoder. Default `8`.
         offset_noise (float, optional): The scale of the offset noise. If not specified, offset noise will not
             be used. Default `None`.
@@ -78,8 +78,8 @@ class StableDiffusion(ComposerModel):
                  inference_noise_scheduler,
                  loss_fn=F.mse_loss,
                  prediction_type: str = 'epsilon',
-                 latent_mean: Optional[List[float]] = None,
-                 latent_std: Optional[List[float]] = None,
+                 latent_mean: Optional[Tuple[float]] = None,
+                 latent_std: Optional[Tuple[float]] = None,
                  downsample_factor: int = 8,
                  offset_noise: Optional[float] = None,
                  train_metrics: Optional[List] = None,
@@ -111,9 +111,9 @@ class StableDiffusion(ComposerModel):
         self.mask_pad_tokens = mask_pad_tokens
         self.sdxl = sdxl
         if latent_mean is None:
-            self.latent_mean = [0.0, 0.0, 0.0, 0.0]
+            self.latent_mean = 4 * (0.0)
         if latent_std is None:
-            self.latent_std = 4 * [1 / 0.13025] if self.sdxl else 4 * [1 / 0.18215]
+            self.latent_std = 4 * (1 / 0.13025,) if self.sdxl else 4 * (1 / 0.18215,)
         self.latent_mean = torch.tensor(latent_mean).view(1, -1, 1, 1)
         self.latent_std = torch.tensor(latent_std).view(1, -1, 1, 1)
         self.train_metrics = train_metrics if train_metrics is not None else [MeanSquaredError()]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,30 @@ import torch
 from diffusion.models.models import stable_diffusion_2, stable_diffusion_xl
 
 
+@pytest.mark.parametrize('latent_mean', [0.1, (0.1, 0.2, 0.3, 0.4)])
+@pytest.mark.parametrize('latent_std', [5.5, (1.1, 2.2, 3.3, 4.4)])
+def test_sd2_latent_scales(latent_mean, latent_std):
+    model = stable_diffusion_2(pretrained=False,
+                               fsdp=False,
+                               encode_latents_in_fp16=False,
+                               latent_mean=latent_mean,
+                               latent_std=latent_std)
+
+    if isinstance(latent_mean, float):
+        latent_mean_comp = [latent_mean] * 4
+    else:
+        latent_mean_comp = latent_mean
+    latent_mean_comp = torch.tensor(latent_mean_comp).view(1, -1, 1, 1).to(model.latent_mean.device)
+    if isinstance(latent_std, float):
+        latent_std_comp = [latent_std] * 4
+    else:
+        latent_std_comp = latent_std
+    latent_std_comp = torch.tensor(latent_std_comp).view(1, -1, 1, 1).to(model.latent_std.device)
+
+    torch.testing.assert_close(model.latent_mean, latent_mean_comp)
+    torch.testing.assert_close(model.latent_std, latent_std_comp)
+
+
 def test_sd2_forward():
     # fp16 vae does not run on cpu
     device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
@@ -45,6 +69,31 @@ def test_sd2_generate(guidance_scale, negative_prompt):
         progress_bar=False,
     )
     assert output.shape == (1, 3, 8, 8)
+
+
+@pytest.mark.parametrize('latent_mean', [0.1, (0.1, 0.2, 0.3, 0.4)])
+@pytest.mark.parametrize('latent_std', [5.5, (1.1, 2.2, 3.3, 4.4)])
+def test_sdxl_latent_scales(latent_mean, latent_std):
+    model = stable_diffusion_xl(pretrained=False,
+                                mask_pad_tokens=True,
+                                fsdp=False,
+                                encode_latents_in_fp16=False,
+                                use_xformers=False,
+                                latent_mean=latent_mean,
+                                latent_std=latent_std)
+    if isinstance(latent_mean, float):
+        latent_mean_comp = [latent_mean] * 4
+    else:
+        latent_mean_comp = latent_mean
+    latent_mean_comp = torch.tensor(latent_mean_comp).view(1, -1, 1, 1).to(model.latent_mean.device)
+    if isinstance(latent_std, float):
+        latent_std_comp = [latent_std] * 4
+    else:
+        latent_std_comp = latent_std
+    latent_std_comp = torch.tensor(latent_std_comp).view(1, -1, 1, 1).to(model.latent_std.device)
+
+    torch.testing.assert_close(model.latent_mean, latent_mean_comp)
+    torch.testing.assert_close(model.latent_std, latent_std_comp)
 
 
 @pytest.mark.parametrize('mask_pad_tokens', [True, False])


### PR DESCRIPTION
This PR adds the option of setting per channel values for the normalization of the autoencoder latents. By default, the scaling uses zero mean and the same scaling value for all channels, which is the previous behavior. One can override this with a scalar for one or both of `latent_mean` or `latent_std` which will use that value for all channels, or specify a tuple of per-channel values. One can also set `latent_mean='latent_statistics'` and/or `latent_std='latent_statistics'` to use the value from the autoencoder checkpoint if it has tracked latent statistics.