### PR TITLE
Arbitrary aspect ratio bucket boundaries

### DIFF
--- a/diffusion/datasets/image_caption.py
+++ b/diffusion/datasets/image_caption.py
@@ -174,6 +174,7 @@ def build_streaming_image_caption_dataloader(
     caption_drop_prob: float = 0.0,
     microcond_drop_prob: float = 0.0,
     resize_size: Union[int, Tuple[int, int], Tuple[Tuple[int, int], ...]] = 256,
+    ar_bucket_boundaries: Optional[Tuple[float, ...]] = None,
     caption_selection: str = 'first',
     transform: Optional[List[Callable]] = None,
     image_key: str = 'image',
@@ -194,16 +195,22 @@ def build_streaming_image_caption_dataloader(
             Should be the same tokenizer passed to the model being trained.
             Can be accessed with model.tokenizer on Diffusion models. Default: ``None``.
         caption_drop_prob (float): The probability of dropping a caption. Default: ``0.0``.
-        microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL. Default: ``0.0``.
+        microcond_drop_prob (float): The probability of dropping microconditioning. Only relevant for SDXL.
+            Default:``0.0``.
         resize_size (int, Tuple[int, int], Tuple[Tuple[int, int], ...): The size to resize the image to. Specify a
             tuple of tuples if using 'aspect_ratio' crop_type. Default: ``256``.
+        ar_bucket_boundaries (Tuple[float, ...], optional): When using ``crop_type='aspect_ratio'``, specifies the
+            boundary points for bucket assignment. This tuple should be of length len(resize_size) - 1. If set to
+            ``None``, the bucket with the smallest distance to the current sample's aspect ratio is selected.
+            Default: ``None``.
         caption_selection (str): If there are multiple captions, specifies how to select a single caption.
             'first' selects the first caption in the list and 'random' selects a random caption in the list.
             If there is only one caption, this argument is ignored. Default: ``'first'``.
         transform (Optional[Callable]): The transforms to apply to the image. Default: ``None``.
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_key (str): Key associated with the caption in the streaming dataset. Default: ``'caption'``.
-        crop_type (str, optional): Type of crop to perform, either ['square', 'random', 'aspect_ratio']. Default: ``'square'``.
+        crop_type (str, optional): Type of crop to perform, either ['square', 'random', 'aspect_ratio'].
+            Default: ``'square'``.
         zero_dropped_captions (bool): If True, zero out text embeddings for dropped captions. Default: ``True``.
         sdxl_conditioning (bool): Whether or not to include SDXL microconditioning in a sample. Default: `False`.
         streaming_kwargs (dict, optional): Additional arguments to pass to the ``StreamingDataset``. Default: ``None``.
@@ -250,7 +257,7 @@ def build_streaming_image_caption_dataloader(
     elif crop_type == 'random':
         crop = RandomCropSquare(resize_size)
     elif crop_type == 'aspect_ratio':
-        crop = RandomCropAspectRatioTransorm(resize_size)  # type: ignore
+        crop = RandomCropAspectRatioTransorm(resize_size, ar_bucket_boundaries)  # type: ignore
     else:
         crop = None
 

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -50,10 +50,12 @@ class RandomCropAspectRatioTransorm:
 
     Args:
         resize_size (Tuple[Tuple[int, int], ...): A tuple of 2-tuple integers representing the aspect ratio buckets.
-            The format is ((height_bucket1, width_bucket1), (height_bucket2, width_bucket2), ...).
+            The format is ((height_bucket1, width_bucket1), (height_bucket2, width_bucket2), ...). These must be
+            ordered based on ascending aspect ratio.
         ar_bucket_boundaries (Tuple[float, ...], optional): Specifies the boundary points for bucket assignment. This
             tuple should be of length len(resize_size) - 1. If set to ``None``, the bucket with the smallest distance
-            to the current sample's aspect ratio is selected. Default: ``None``
+            to the current sample's aspect ratio is selected. These must be ordered based on ascending aspect ratio.
+            Default: ``None``
     """
 
     def __init__(

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -78,10 +78,11 @@ class RandomCropAspectRatioTransorm:
         orig_aspect_ratio = orig_h / orig_w
 
         # Assign sample to an aspect ratio bucket
-        bucket_ind = None
+
         if self.ar_bucket_boundaries is None:
             bucket_ind = torch.abs(self.aspect_ratio_buckets - orig_aspect_ratio).argmin()
         else:
+            bucket_ind = None
             for i, (low, high) in enumerate(zip(self.ar_bucket_boundaries[:-1], self.ar_bucket_boundaries[1:])):
                 if (i < len(self.aspect_ratio_buckets) // 2) and (low <= orig_aspect_ratio < high):
                     bucket_ind = i
@@ -89,8 +90,8 @@ class RandomCropAspectRatioTransorm:
                     bucket_ind = i
                 elif (i > len(self.aspect_ratio_buckets) // 2) and (low < orig_aspect_ratio <= high):
                     bucket_ind = i
+            assert bucket_ind is not None, f'Sample with aspect ratio ({orig_aspect_ratio}) was not assigned to a bucket. Check the bucket boundaries'
 
-        assert bucket_ind
         target_width, target_height = self.width_buckets[bucket_ind].item(), self.height_buckets[bucket_ind].item()
         target_aspect_ratio = target_height / target_width
 

--- a/diffusion/datasets/laion/transforms.py
+++ b/diffusion/datasets/laion/transforms.py
@@ -78,7 +78,6 @@ class RandomCropAspectRatioTransorm:
         orig_aspect_ratio = orig_h / orig_w
 
         # Assign sample to an aspect ratio bucket
-
         if self.ar_bucket_boundaries is None:
             bucket_ind = torch.abs(self.aspect_ratio_buckets - orig_aspect_ratio).argmin()
         else:
@@ -90,7 +89,7 @@ class RandomCropAspectRatioTransorm:
                     bucket_ind = i
                 elif (i > len(self.aspect_ratio_buckets) // 2) and (low < orig_aspect_ratio <= high):
                     bucket_ind = i
-            assert bucket_ind is not None, f'Sample with aspect ratio ({orig_aspect_ratio}) was not assigned to a bucket. Check the bucket boundaries'
+            assert bucket_ind is not None, f'Sample with aspect ratio ({orig_aspect_ratio}) was not assigned to a bucket. Check the bucket boundaries.'
 
         target_width, target_height = self.width_buckets[bucket_ind].item(), self.height_buckets[bucket_ind].item()
         target_aspect_ratio = target_height / target_width


### PR DESCRIPTION
Currently, a sample is assigned to the aspect ratio bucket with the smallest distance to the sample's aspect ratio bucket i.e. `torch.abs(self.aspect_ratio_buckets - orig_aspect_ratio).argmin()`. This results in implicit boundary conditions which are unlikely to optimal for reducing  overall max cropping and having similar max crops across buckets.

This PR adds an argument to specify the boundaries between aspect ratio buckets, allowing control over the max cropping across buckets.