### PR TITLE
Bug to enable fp16

### DIFF
--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -385,6 +385,7 @@ class StableDiffusion(ComposerModel):
             (batch_size, self.unet.config.in_channels, height // self.downsample_factor,
              width // self.downsample_factor),
             device=device,
+            dtype=self.unet.dtype,
             generator=rng_generator,
         )
 


### PR DESCRIPTION
Latents are created based on default torch dtype but should be using dtype that the model is set to. Needed for inference