### PR TITLE
Fix autoencoder load

### DIFF
--- a/diffusion/models/autoencoder.py
+++ b/diffusion/models/autoencoder.py
@@ -766,7 +766,7 @@ def load_autoencoder(load_path: str,
     """
     # Download the autoencoder weights and init them
     if dist.get_local_rank() == 0:
-        get_file(path=load_path, destination=local_path)
+        get_file(path=load_path, destination=local_path, overwrite=True)
     with dist.local_rank_zero_download_and_wait(local_path):
         # Load the autoencoder weights from the state dict
         state_dict = torch.load(local_path, map_location='cpu')

--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -385,6 +385,7 @@ class StableDiffusion(ComposerModel):
             (batch_size, self.unet.config.in_channels, height // self.downsample_factor,
              width // self.downsample_factor),
             device=device,
+            dtype=self.unet.dtype,
             generator=rng_generator,
         )
 


### PR DESCRIPTION
Current autoencoder loading only works the first time. for inference if a model ever goes down and restarts, the load step is called again, but if overwrite isn't set it fails on creating the symlink cause it already exists.