### PR TITLE
Fix bug in stable diffusion when mask_pad_tokens is false

### DIFF
--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -484,7 +484,10 @@ class StableDiffusion(ComposerModel):
                                                truncation=True,
                                                return_tensors='pt')
                 tokenized_prompts = tokenized_out['input_ids']
-                tokenized_pad_mask = tokenized_out['attention_mask']
+                if self.mask_pad_tokens:
+                    tokenized_pad_mask = tokenized_out['attention_mask']
+                else:
+                    tokenized_pad_mask = None
             if tokenized_pad_mask is not None:
                 tokenized_pad_mask = tokenized_pad_mask.to(device)
             text_encoder_out = self.text_encoder(tokenized_prompts.to(device), attention_mask=tokenized_pad_mask)


### PR DESCRIPTION
Currently when `mask_pad_tokens=False` in the stable diffusion model, the mask is still passed to the text encoder at generation time. This introduces a train/test mismatch because the masked tokens in the text encoder output are different from the unmasked tokens, and the model is trained with the unmasked pad tokens. The result is a degradation in image quality. The fix is to only use the mask from the tokenizer output if `mask_pad_tokens=True`.