### PR TITLE
Only use a text encoder mask in SD model forward if mask_pad_tokens is false

### DIFF
--- a/diffusion/models/stable_diffusion.py
+++ b/diffusion/models/stable_diffusion.py
@@ -182,11 +182,9 @@ class StableDiffusion(ComposerModel):
 
     def forward(self, batch):
         latents, text_embeds, text_pooled_embeds, attention_mask, encoder_attention_mask = None, None, None, None, None
-        if 'attention_mask' in batch:
+        if 'attention_mask' in batch and self.mask_pad_tokens:
             attention_mask = batch['attention_mask']  # mask for text encoders
-            # text mask for U-Net
-            if self.mask_pad_tokens:
-                encoder_attention_mask = _create_unet_attention_mask(attention_mask)
+            encoder_attention_mask = _create_unet_attention_mask(attention_mask)  # text mask for U-Net
 
         # Use latents if specified and available. When specified, they might not exist during eval
         if self.precomputed_latents and self.image_latents_key in batch and self.text_latents_key in batch:


### PR DESCRIPTION
As is, we have a train/test mismatch when `mask_pad_tokens = False` where the mask is applied to the text encoder at generation time as expected by SDXL, but not during training time. This PR changes the train behavior to match the expected generation time behavior.