### PR TITLE
LoRA Load Planner

### DIFF
--- a/diffusion/planners/__init__.py
+++ b/diffusion/planners/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composer checkpointing planners."""
+
+from diffusion.planners.lora_planner import LoraPlanner
+
+__all__ = ['LoraPlanner']

--- a/diffusion/planners/lora_planner.py
+++ b/diffusion/planners/lora_planner.py
@@ -1,0 +1,58 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""LoRA Planner."""
+from torch.distributed.checkpoint._nested_dict import flatten_state_dict
+from torch.distributed.checkpoint._sharded_tensor_utils import _flatten_sharded_tensors
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
+from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE, Metadata
+
+__all__ = ['LoraPlanner']
+
+
+class LoraPlanner(DefaultLoadPlanner):
+    """Takes a Composer checkpoint and converts it to LoRA Checkpoint."""
+
+    def set_up_planner(
+        self,
+        state_dict: STATE_DICT_TYPE,
+        metadata: Metadata,
+        is_coordinator: bool,
+    ) -> None:
+        """Sets up the planner for converting Composer to LoRA Checkpoint.
+
+        Takes all targeted modules and checks whether they have been LoRA processed. If not,
+        changes names of weights appropriately. If yes, doesn't change anything for autoresume
+        compatibility.
+
+        Args:
+            state_dict (STATE_DICT_TYPE): Original torch state dict.
+            metadata (METADATA): Any metadata associated with the state dict.
+            is_coordinator (bool): Whether the machine this is running on is the coordinator of loading.
+        """
+        if 'state' not in state_dict:
+            super().set_up_planner(state_dict, metadata, is_coordinator)
+            return
+
+        self.original_state_dict = state_dict
+
+        state_dict = dict(state_dict.items())
+        state_dict['state'] = dict(state_dict['state'].items())
+        target_modules = ['to_k', 'to_v', 'to_q', 'to_out.0']
+
+        for key in state_dict['state']['model'].keys():
+            for mod in target_modules:
+                if f'{mod}.weight' in key:
+                    new_key = key.replace(mod, mod + '.base_layer')
+                    state_dict['state']['model'][new_key] = state_dict['state']['model'].pop(key)
+                    break
+
+        if self.flatten_sharded_tensors:
+            state_dict = _flatten_sharded_tensors(state_dict)
+
+        if self.flatten_state_dict:
+            state_dict, self.mappings = flatten_state_dict(state_dict)
+
+        self.state_dict = state_dict
+        self.metadata = metadata
+        self.is_coordinator = is_coordinator

--- a/diffusion/train.py
+++ b/diffusion/train.py
@@ -21,6 +21,7 @@ from torch.optim import Optimizer
 
 from diffusion.models.autoencoder import ComposerAutoEncoder, ComposerDiffusersAutoEncoder
 from diffusion.models.t2i_transformer import ComposerTextToImageMMDiT
+from diffusion.planners import LoraPlanner
 
 
 def make_autoencoder_optimizer(config: DictConfig, model: ComposerModel) -> Optimizer:
@@ -205,6 +206,12 @@ def train(config: DictConfig) -> None:
             if '_target_' in call_conf:
                 print(f'Instantiating callbacks <{call_conf._target_}>')
                 callbacks.append(hydra.utils.instantiate(call_conf))
+
+    if 'planners' in config:
+        for pl_name, pl_conf in config.planners.items():
+            if pl_name == 'lora_planner' and pl_conf:
+                assert 'fsdp_config' in config.trainer
+                config.trainer.fsdp_config.load_planner = LoraPlanner
 
     scheduler = hydra.utils.instantiate(config.scheduler)
 


### PR DESCRIPTION
This PR adds a Load Planner that renames target modules of LoRA so that we can take a Composer checkpoint without LoRA and then use it to load and train a LoRA model.

Also support autoresume out-of-box by not modifying the checkpoint if LoRA is already used.