### PR TITLE
Add composer model class for running with precomputed CLIP and T5 text latents

### DIFF
--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -39,6 +39,11 @@ class LogDiffusionImages(Callback):
         use_table (bool): Whether to make a table of the images or not. Default: ``False``.
         t5_encoder (str, optional): path to the T5 encoder to as a second text encoder.
         clip_encoder (str, optional): path to the CLIP encoder as the first text encoder.
+        t5_latent_key: (str): key to use for the T5 latents in the batch. Default: ``'T5_LATENTS'``.
+        t5_mask_key: (str): key to use for the T5 attention mask in the batch. Default: ``'T5_ATTENTION_MASK'``.
+        clip_latent_key: (str): key to use for the CLIP latents in the batch. Default: ``'CLIP_LATENTS'``.
+        clip_mask_key: (str): key to use for the CLIP attention mask in the batch. Default: ``'CLIP_ATTENTION_MASK'``.
+        clip_pooled_key: (str): key to use for the CLIP pooled in the batch. Default: ``'CLIP_POOLED'``.
         cache_dir: (str, optional): path for HF to cache files while downloading model
     """
 
@@ -53,6 +58,11 @@ class LogDiffusionImages(Callback):
                  use_table: bool = False,
                  t5_encoder: Optional[str] = None,
                  clip_encoder: Optional[str] = None,
+                 t5_latent_key: str = 'T5_LATENTS',
+                 t5_mask_key: str = 'T5_ATTENTION_MASK',
+                 clip_latent_key: str = 'CLIP_LATENTS',
+                 clip_mask_key: str = 'CLIP_ATTENTION_MASK',
+                 clip_pooled_key: str = 'CLIP_POOLED',
                  cache_dir: Optional[str] = '/tmp/hf_files'):
         self.prompts = prompts
         self.size = (size, size) if isinstance(size, int) else size
@@ -61,6 +71,11 @@ class LogDiffusionImages(Callback):
         self.rescaled_guidance = rescaled_guidance
         self.seed = seed
         self.use_table = use_table
+        self.t5_latent_key = t5_latent_key
+        self.t5_mask_key = t5_mask_key
+        self.clip_latent_key = clip_latent_key
+        self.clip_mask_key = clip_mask_key
+        self.clip_pooled_key = clip_pooled_key
         self.cache_dir = cache_dir
 
         # Batch prompts
@@ -120,11 +135,11 @@ class LogDiffusionImages(Callback):
                 clip_pooled = clip_outputs[1].cpu()
                 clip_attention_mask = clip_attention_mask.cpu().to(torch.long)
 
-                latent_batch['T5_LATENTS'] = t5_latents
-                latent_batch['T5_ATTENTION_MASK'] = t5_attention_mask
-                latent_batch['CLIP_LATENTS'] = clip_latents
-                latent_batch['CLIP_ATTENTION_MASK'] = clip_attention_mask
-                latent_batch['CLIP_POOLED'] = clip_pooled
+                latent_batch[self.t5_latent_key] = t5_latents
+                latent_batch[self.t5_mask_key] = t5_attention_mask
+                latent_batch[self.clip_latent_key] = clip_latents
+                latent_batch[self.clip_mask_key] = clip_attention_mask
+                latent_batch[self.clip_pooled_key] = clip_pooled
                 self.batched_latents.append(latent_batch)
 
             del t5_model
@@ -144,11 +159,11 @@ class LogDiffusionImages(Callback):
             all_gen_images = []
             if self.precomputed_latents:
                 for batch in self.batched_latents:
-                    pooled_prompt = batch['CLIP_POOLED'].cuda()
-                    prompt_embeds, prompt_mask = model.prepare_text_embeddings(batch['T5_LATENTS'].cuda(),
-                                                                               batch['CLIP_LATENTS'].cuda(),
-                                                                               batch['T5_ATTENTION_MASK'].cuda(),
-                                                                               batch['CLIP_ATTENTION_MASK'].cuda())
+                    pooled_prompt = batch[self.clip_pooled_key].cuda()
+                    prompt_embeds, prompt_mask = model.prepare_text_embeddings(batch[self.t5_latent_key].cuda(),
+                                                                               batch[self.clip_latent_key].cuda(),
+                                                                               batch[self.t5_mask_key].cuda(),
+                                                                               batch[self.clip_mask_key].cuda())
                     gen_images = model.generate(prompt_embeds=prompt_embeds,
                                                 pooled_prompt=pooled_prompt,
                                                 prompt_mask=prompt_mask,

--- a/diffusion/datasets/image_caption_latents.py
+++ b/diffusion/datasets/image_caption_latents.py
@@ -151,14 +151,12 @@ class StreamingImageCaptionLatentsDataset(StreamingDataset):
                     clip_pooled = np.frombuffer(sample[f'{caption_key}_CLIP_POOLED_TEXT'], dtype=np.float32).copy()
                     out['CLIP_POOLED'] = torch.from_numpy(clip_pooled).to(self.latent_dtype).reshape(latent_shape[1])
         if self.drop_nans:
-            if out['CLIP_POOLED'].isnan().any():
-                out['CLIP_POOLED'] = torch.zeros_like(out['CLIP_POOLED'])
-            if out['T5_LATENTS'].isnan().any():
-                out['T5_LATENTS'] = torch.zeros_like(out['T5_LATENTS'])
-                out['T5_ATTENTION_MASK'] = torch.zeros_like(out['T5_ATTENTION_MASK'])
-            if out['CLIP_LATENTS'].isnan().any():
-                out['CLIP_LATENTS'] = torch.zeros_like(out['CLIP_LATENTS'])
-                out['CLIP_ATTENTION_MASK'] = torch.zeros_like(out['CLIP_ATTENTION_MASK'])
+            for latent_key, attn_key in zip(self.text_latent_keys, self.attention_mask_keys):
+                if out[latent_key].isnan().any():
+                    out[latent_key] = torch.zeros_like(out[latent_key])
+                    out[attn_key] = torch.zeros_like(out[attn_key])
+                if 'CLIP_LATENTS' in latent_key and out['CLIP_POOLED'].isnan().any():
+                    out['CLIP_POOLED'] = torch.zeros_like(out['CLIP_POOLED'])
         return out
 
 

--- a/diffusion/datasets/image_caption_latents.py
+++ b/diffusion/datasets/image_caption_latents.py
@@ -140,6 +140,14 @@ class StreamingImageCaptionLatentsDataset(StreamingDataset):
                 if 'CLIP_LATENTS' in latent_key:
                     clip_pooled = np.frombuffer(sample[f'{caption_key}_CLIP_POOLED_TEXT'], dtype=np.float32).copy()
                     out['CLIP_POOLED'] = torch.from_numpy(clip_pooled).to(self.latent_dtype).reshape(latent_shape[1])
+        if out['CLIP_POOLED'].isnan().any():
+            out['CLIP_POOLED'] = torch.zeros_like(out['CLIP_POOLED'])
+        if out['T5_LATENTS'].isnan().any():
+            out['T5_LATENTS'] = torch.zeros_like(out['T5_LATENTS'])
+            out['T5_ATTENTION_MASK'] = torch.zeros_like(out['T5_ATTENTION_MASK'])
+        if out['CLIP_LATENTS'].isnan().any():
+            out['CLIP_LATENTS'] = torch.zeros_like(out['CLIP_LATENTS'])
+            out['CLIP_ATTENTION_MASK'] = torch.zeros_like(out['CLIP_ATTENTION_MASK'])
         return out
 
 

--- a/diffusion/datasets/image_caption_latents.py
+++ b/diffusion/datasets/image_caption_latents.py
@@ -14,7 +14,8 @@ from streaming import Stream, StreamingDataset
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from diffusion.datasets.laion.transforms import LargestCenterSquare, RandomCropAspectRatioTransform, RandomCropSquare
+from diffusion.datasets.laion.transforms import (LargestCenterSquare, RandomCropAspectRatioTransform,
+                                                 RandomCropBucketedAspectRatioTransform, RandomCropSquare)
 from diffusion.datasets.utils import make_streams
 
 log = logging.getLogger(__name__)
@@ -172,6 +173,7 @@ def build_streaming_image_caption_latents_dataloader(
     text_latent_shapes: Tuple[Tuple, ...] = ((512, 4096), (77, 768)),
     attention_mask_keys: Tuple[str, ...] = ('T5_ATTENTION_MASK', 'CLIP_ATTENTION_MASK'),
     latent_dtype: str = 'torch.bfloat16',
+    aspect_ratio_bucket_key: Optional[str] = None,
     streaming_kwargs: Optional[Dict] = None,
     dataloader_kwargs: Optional[Dict] = None,
 ):
@@ -190,11 +192,12 @@ def build_streaming_image_caption_latents_dataloader(
             ``None``, the bucket with the smallest distance to the current sample's aspect ratio is selected.
             Default: ``None``.
         transform (Callable, optional): The transforms to apply to the image. Default: ``None``.
-        crop_type (str, optional): Type of crop to perform, either ['square', 'random', 'aspect_ratio'].
+        crop_type (str, optional): Type of crop to perform, either ['square', 'random', 'aspect_ratio', 'bucketed_aspect_ratio'].
             Default: ``'square'``.
         image_key (str): Key associated with the image in the streaming dataset. Default: ``'image'``.
         caption_keys (Tuple[str, ...]): Key(s) associated with captions in the streaming dataset. Default: ``('caption',)``.
         caption_selection_probs (Tuple[float, ...]): The probability of selecting each caption key. Default: ``(1.0,)``.
+        aspect_ratio_bucket_key (str, optional): Key associated with the aspect ratio bucket in the streaming dataset. Default: ``None``.
         text_latent_keys (Tuple[str, ...]): Key(s) associated with text latents in the streaming dataset.
             Default: ``('T5_LATENTS', 'CLIP_LATENTS')``.
         text_latent_shapes (Tuple[Tuple[int, int], ...]): The shape(s) of the text latents in the streaming dataset.
@@ -204,18 +207,22 @@ def build_streaming_image_caption_latents_dataloader(
             Default: ``('T5_ATTENTION_MASK', 'CLIP_ATTENTION_MASK')``.
         latent_dtype (str): The torch dtype to cast the text latents to. One of 'torch.float16', 'torch.float32',
             or 'torch.bfloat16'. Default: ``'torch.bfloat16'``.
+        aspect_ratio_bucket_key (str, optional): Key associated with the aspect ratio bucket in the streaming dataset.
+            Needed if using ``crop_type='bucketed_aspect_ratio'``. Default: ``None``.
         streaming_kwargs (dict, optional): Additional arguments to pass to the ``StreamingDataset``. Default: ``None``.
         dataloader_kwargs (dict, optional): Additional arguments to pass to the ``DataLoader``. Default: ``None``.
     """
     # Check crop type
     if crop_type is not None:
         crop_type = crop_type.lower()
-        if crop_type not in ['square', 'random', 'aspect_ratio']:
-            raise ValueError(f'Invalid crop_type: {crop_type}. Must be ["square", "random", "aspect_ratio", None]')
-        if crop_type == 'aspect_ratio' and (isinstance(resize_size, int) or isinstance(resize_size[0], int)):
+        if crop_type not in ['square', 'random', 'aspect_ratio', 'bucketed_aspect_ratio']:
             raise ValueError(
-                'If using crop_type="aspect_ratio", specify aspect ratio buckets in resize_size as a tuple of tuples.')
-
+                f'Invalid crop_type: {crop_type}. Must be ["square", "random", "aspect_ratio", "bucketed_aspect_ratio", None]'
+            )
+        if crop_type in ['aspect_ratio', 'bucketed_aspect_ratio'] and (isinstance(resize_size, int) or
+                                                                       isinstance(resize_size[0], int)):
+            raise ValueError(
+                'If using aspect ratio bucketing, specify aspect ratio buckets in resize_size as a tuple of tuples.')
     # Check latent dtype
     dtypes = {'torch.float16': torch.float16, 'torch.float32': torch.float32, 'torch.bfloat16': torch.bfloat16}
     assert latent_dtype in dtypes, f'Invalid latent_dtype: {latent_dtype}. Must be one of {list(dtypes.keys())}'
@@ -237,6 +244,9 @@ def build_streaming_image_caption_latents_dataloader(
         crop = RandomCropSquare(resize_size)
     elif crop_type == 'aspect_ratio':
         crop = RandomCropAspectRatioTransform(resize_size, ar_bucket_boundaries)  # type: ignore
+    elif crop_type == 'bucketed_aspect_ratio':
+        assert aspect_ratio_bucket_key is not None, 'aspect_ratio_bucket_key must be provided when using bucketed_aspect_ratio crop type'
+        crop = RandomCropBucketedAspectRatioTransform(resize_size)  # type: ignore
     else:
         crop = None
 

--- a/diffusion/models/__init__.py
+++ b/diffusion/models/__init__.py
@@ -20,5 +20,6 @@ __all__ = [
     'stable_diffusion_2',
     'stable_diffusion_xl',
     'StableDiffusion',
+    'TextLatentDiffusion',
     'text_to_image_transformer',
 ]

--- a/diffusion/models/__init__.py
+++ b/diffusion/models/__init__.py
@@ -8,6 +8,7 @@ from diffusion.models.models import (build_autoencoder, build_diffusers_autoenco
                                      text_to_image_transformer)
 from diffusion.models.noop import NoOpModel
 from diffusion.models.pixel_diffusion import PixelDiffusion
+from diffusion.models.precomputed_text_latent_diffusion import PrecomputedTextLatentDiffusion
 from diffusion.models.stable_diffusion import StableDiffusion
 
 __all__ = [
@@ -20,6 +21,6 @@ __all__ = [
     'stable_diffusion_2',
     'stable_diffusion_xl',
     'StableDiffusion',
-    'TextLatentDiffusion',
+    'PrecomputedTextLatentDiffusion',
     'text_to_image_transformer',
 ]

--- a/diffusion/models/__init__.py
+++ b/diffusion/models/__init__.py
@@ -4,8 +4,8 @@
 """Diffusion models."""
 
 from diffusion.models.models import (build_autoencoder, build_diffusers_autoencoder, continuous_pixel_diffusion,
-                                     discrete_pixel_diffusion, stable_diffusion_2, stable_diffusion_xl,
-                                     text_to_image_transformer)
+                                     discrete_pixel_diffusion, precomputed_text_latent_diffusion, stable_diffusion_2,
+                                     stable_diffusion_xl, text_to_image_transformer)
 from diffusion.models.noop import NoOpModel
 from diffusion.models.pixel_diffusion import PixelDiffusion
 from diffusion.models.precomputed_text_latent_diffusion import PrecomputedTextLatentDiffusion
@@ -18,6 +18,7 @@ __all__ = [
     'discrete_pixel_diffusion',
     'NoOpModel',
     'PixelDiffusion',
+    'precomputed_text_latent_diffusion',
     'stable_diffusion_2',
     'stable_diffusion_xl',
     'StableDiffusion',

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -18,10 +18,10 @@ from diffusion.models.autoencoder import (AutoEncoder, AutoEncoderLoss, Composer
                                           ComposerDiffusersAutoEncoder, load_autoencoder)
 from diffusion.models.layers import ClippedAttnProcessor2_0, ClippedXFormersAttnProcessor, zero_module
 from diffusion.models.pixel_diffusion import PixelDiffusion
+from diffusion.models.precomputed_text_latent_diffusion import PrecomputedTextLatentDiffusion
 from diffusion.models.stable_diffusion import StableDiffusion
 from diffusion.models.t2i_transformer import ComposerTextToImageMMDiT
 from diffusion.models.text_encoder import MultiTextEncoder, MultiTokenizer
-from diffusion.models.text_latent_diffusion import PrecomputedTextLatentDiffusion
 from diffusion.models.transformer import DiffusionTransformer
 from diffusion.schedulers.schedulers import ContinuousTimeScheduler
 from diffusion.schedulers.utils import shift_noise_schedule
@@ -627,6 +627,7 @@ def build_text_latent_diffusion(
         latent_std (float, Tuple, str): The std. dev. of the autoencoder latents. Either a float for a single value,
             a tuple of std_devs, or or `'latent_statistics'` to try to use the value from the autoencoder
             checkpoint. Defaults to `1/0.13025`.
+        text_embed_dim (int): The dimension to project the text embeddings to. Default: `4096`.
         beta_schedule (str): The beta schedule to use. Must be one of 'scaled_linear', 'linear', or 'squaredcos_cap_v2'.
             Default: `scaled_linear`.
         zero_terminal_snr (bool): Whether to enforce zero terminal SNR. Default: `False`.
@@ -681,7 +682,7 @@ def build_text_latent_diffusion(
         unet_config['in_channels'] = vae.config['latent_channels']
         unet_config['out_channels'] = vae.config['latent_channels']
     unet_config['cross_attention_dim'] = text_embed_dim
-    # This config variable is the sum of the text encoder projection dimension (768 for CLIP) and
+    # This config variable is the sum of the text encoder projection dimension and
     # the number of additional time embeddings (6) * addition_time_embed_dim (256)
     unet_config['projection_class_embeddings_input_dim'] = 2304
     # Init the unet from the config

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -20,8 +20,8 @@ from diffusion.models.layers import ClippedAttnProcessor2_0, ClippedXFormersAttn
 from diffusion.models.pixel_diffusion import PixelDiffusion
 from diffusion.models.stable_diffusion import StableDiffusion
 from diffusion.models.t2i_transformer import ComposerTextToImageMMDiT
-from diffusion.models.t5_diffusion import DiffusionV1
 from diffusion.models.text_encoder import MultiTextEncoder, MultiTokenizer
+from diffusion.models.text_latent_diffusion import PrecomputedTextLatentDiffusion
 from diffusion.models.transformer import DiffusionTransformer
 from diffusion.schedulers.schedulers import ContinuousTimeScheduler
 from diffusion.schedulers.utils import shift_noise_schedule
@@ -581,7 +581,7 @@ def stable_diffusion_xl(
     return model
 
 
-def build_diffusion_v1(
+def build_text_latent_diffusion(
     unet_model_name: str = 'stabilityai/stable-diffusion-xl-base-1.0',
     vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
     autoencoder_path: Optional[str] = None,
@@ -779,7 +779,7 @@ def build_diffusion_v1(
                                                      cache_dir=cache_dir,
                                                      local_files_only=True).cuda().eval()
     # Make the composer model
-    model = DiffusionV1(
+    model = PrecomputedTextLatentDiffusion(
         unet=unet,
         vae=vae,
         t5_tokenizer=t5_tokenizer,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -581,7 +581,7 @@ def stable_diffusion_xl(
     return model
 
 
-def build_text_latent_diffusion(
+def precomputed_text_latent_diffusion(
     unet_model_name: str = 'stabilityai/stable-diffusion-xl-base-1.0',
     vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
     autoencoder_path: Optional[str] = None,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -587,7 +587,7 @@ def precomputed_text_latent_diffusion(
     autoencoder_path: Optional[str] = None,
     autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
     include_text_encoders: bool = False,
-    text_encoder_dtype: str = 'float16',
+    text_encoder_dtype: str = 'bfloat16',
     cache_dir: str = '/tmp/hf_files',
     prediction_type: str = 'epsilon',
     image_key: str = 'image',
@@ -626,7 +626,7 @@ def precomputed_text_latent_diffusion(
         include_text_encoders (bool): Whether to include text encoders in the model. Should only do this for running
             inference. Default: `False`.
         text_encoder_dtype (str): The dtype to use for the text encoder. One of [`float32`, `float16`, `bfloat16`].
-            Default: `float16`.
+            Default: `bfloat16`.
         cache_dir (str): Directory to cache the model in if using `include_text_encoders`. Default: `'/tmp/hf_files'`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -590,6 +590,12 @@ def precomputed_text_latent_diffusion(
     text_encoder_dtype: str = 'float16',
     cache_dir: str = '/tmp/hf_files',
     prediction_type: str = 'epsilon',
+    image_key: str = 'image',
+    t5_latent_key: str = 'T5_LATENTS',
+    t5_mask_key: str = 'T5_ATTENTION_MASK',
+    clip_latent_key: str = 'CLIP_LATENTS',
+    clip_mask_key: str = 'CLIP_ATTENTION_MASK',
+    clip_pooled_key: str = 'CLIP_POOLED',
     latent_mean: Union[float, Tuple, str] = 0.0,
     latent_std: Union[float, Tuple, str] = 7.67754318618,
     text_embed_dim: int = 4096,
@@ -624,6 +630,12 @@ def precomputed_text_latent_diffusion(
         cache_dir (str): Directory to cache the model in if using `include_text_encoders`. Default: `'/tmp/hf_files'`.
         prediction_type (str): The type of prediction to use. Must be one of 'sample',
             'epsilon', or 'v_prediction'. Default: `epsilon`.
+        image_key (str): The key to use for the image in the precomputed latents. Default: `'image'`.
+        t5_latent_key (str): The key to use for the T5 latents in the precomputed latents. Default: `'T5_LATENTS'`.
+        t5_mask_key (str): The key to use for the T5 attention mask in the precomputed latents. Default: `'T5_ATTENTION_MASK'`.
+        clip_latent_key (str): The key to use for the CLIP latents in the precomputed latents. Default: `'CLIP_LATENTS'`.
+        clip_mask_key (str): The key to use for the CLIP attention mask in the precomputed latents. Default: `'CLIP_ATTENTION_MASK'`.
+        clip_pooled_key (str): The key to use for the CLIP pooled in the precomputed latents. Default: `'CLIP_POOLED'`.
         latent_mean (float, Tuple, str): The mean of the autoencoder latents. Either a float for a single value,
             a tuple of means, or or `'latent_statistics'` to try to use the value from the autoencoder
             checkpoint. Defaults to `0.0`.
@@ -807,6 +819,12 @@ def precomputed_text_latent_diffusion(
         noise_scheduler=noise_scheduler,
         inference_noise_scheduler=inference_noise_scheduler,
         prediction_type=prediction_type,
+        image_key=image_key,
+        t5_latent_key=t5_latent_key,
+        t5_mask_key=t5_mask_key,
+        clip_latent_key=clip_latent_key,
+        clip_mask_key=clip_mask_key,
+        clip_pooled_key=clip_pooled_key,
         latent_mean=latent_mean,
         latent_std=latent_std,
         downsample_factor=downsample_factor,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -594,6 +594,7 @@ def precomputed_text_latent_diffusion(
     text_embed_dim: int = 4096,
     train_noise_scheduler_params: Optional[Dict[str, Any]] = None,
     inference_noise_scheduler_params: Optional[Dict[str, Any]] = None,
+    scheduler_shift_resolution: int = 256,
     train_metrics: Optional[List] = None,
     val_metrics: Optional[List] = None,
     quasirandomness: bool = False,
@@ -629,6 +630,7 @@ def precomputed_text_latent_diffusion(
             specified will default to SDXL values. Default: `None`.
         inference_noise_scheduler_params (Dict): Parameters to overried in the inference noise scheduler. Anything
             not specified will default to SDXL values. Default: `None`.
+        scheduler_shift_resolution (int): The resolution to shift the noise scheduler to. Default: `256`.
         train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
             [MeanSquaredError()].
         val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
@@ -759,6 +761,14 @@ def precomputed_text_latent_diffusion(
     if inference_noise_scheduler_params is not None:
         inference_scheduler_params.update(inference_noise_scheduler_params)
     inference_noise_scheduler = EulerDiscreteScheduler(**inference_scheduler_params)
+
+    # Shift noise scheduler to correct for resolution changes
+    noise_scheduler = shift_noise_schedule(noise_scheduler,
+                                           base_dim=32,
+                                           shift_dim=scheduler_shift_resolution // downsample_factor)
+    inference_noise_scheduler = shift_noise_schedule(inference_noise_scheduler,
+                                                     base_dim=32,
+                                                     shift_dim=scheduler_shift_resolution // downsample_factor)
 
     # Optionally load the tokenizers and text encoders
     t5_tokenizer, t5_encoder, clip_tokenizer, clip_encoder = None, None, None, None

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -769,16 +769,16 @@ def precomputed_text_latent_diffusion(
         clip_tokenizer = AutoTokenizer.from_pretrained('stabilityai/stable-diffusion-xl-base-1.0',
                                                        subfolder='tokenizer',
                                                        cache_dir=cache_dir,
-                                                       local_files_only=True)
+                                                       local_files_only=False)
         t5_encoder = AutoModel.from_pretrained('google/t5-v1_1-xxl',
-                                               torch_dtype=torch.bfloat16,
+                                               torch_dtype=torch.float16,
                                                cache_dir=cache_dir,
-                                               local_files_only=True).encoder.eval()
+                                               local_files_only=False).encoder.eval()
         clip_encoder = CLIPTextModel.from_pretrained('stabilityai/stable-diffusion-xl-base-1.0',
                                                      subfolder='text_encoder',
-                                                     torch_dtype=torch.bfloat16,
+                                                     torch_dtype=torch.float16,
                                                      cache_dir=cache_dir,
-                                                     local_files_only=True).cuda().eval()
+                                                     local_files_only=False).cuda().eval()
     # Make the composer model
     model = PrecomputedTextLatentDiffusion(
         unet=unet,

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -602,10 +602,7 @@ def precomputed_text_latent_diffusion(
     fsdp: bool = True,
     use_xformers: bool = True,
 ):
-    """Stable diffusion 2 training setup + SDXL UNet and VAE.
-
-    Requires batches of matched images and text prompts to train. Generates images from text
-    prompts. Currently uses UNet and VAE config from SDXL, but text encoder/tokenizer from SD2.
+    """Latent diffusion model training using precomputed text latents from T5-XXL and CLIP.
 
     Args:
         unet_model_name (str): Name of the UNet model to load. Defaults to

--- a/diffusion/models/precomputed_text_latent_diffusion.py
+++ b/diffusion/models/precomputed_text_latent_diffusion.py
@@ -171,7 +171,7 @@ class PrecomputedTextLatentDiffusion(ComposerModel):
         self.rng_generator = rng_generator
 
     def encode_images(self, inputs, dtype=torch.bfloat16):
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             latents = self.vae.encode(inputs.to(dtype))['latent_dist'].sample().data
         latents = (latents - self.latent_mean) / self.latent_std  # scale latents
         return latents

--- a/diffusion/models/precomputed_text_latent_diffusion.py
+++ b/diffusion/models/precomputed_text_latent_diffusion.py
@@ -191,18 +191,18 @@ class PrecomputedTextLatentDiffusion(ComposerModel):
                                              max_length=self.t5_tokenizer.model_max_length,
                                              truncation=True,
                                              return_tensors='pt')
-        tokenized_captions = t5_tokenizer_out['input_ids'].to(device)
+        t5_tokenized_captions = t5_tokenizer_out['input_ids'].to(device)
         t5_attn_mask = t5_tokenizer_out['attention_mask'].to(torch.bool).to(device)
-        t5_embed = self.t5_encoder(input_ids=tokenized_captions, attention_mask=t5_attn_mask)
+        t5_embed = self.t5_encoder(input_ids=t5_tokenized_captions, attention_mask=t5_attn_mask)[0]
         # Encode with CLIP
         clip_tokenizer_out = self.clip_tokenizer(text,
                                                  padding='max_length',
                                                  max_length=self.clip_tokenizer.model_max_length,
                                                  truncation=True,
                                                  return_tensors='pt')
-        tokenized_captions = clip_tokenizer_out['input_ids'].to(device)
+        clip_tokenized_captions = clip_tokenizer_out['input_ids'].to(device)
         clip_attn_mask = clip_tokenizer_out['attention_mask'].to(torch.bool).to(device)
-        clip_out = self.clip_encoder(input_ids=tokenized_captions,
+        clip_out = self.clip_encoder(input_ids=clip_tokenized_captions,
                                      attention_mask=clip_attn_mask,
                                      output_hidden_states=True)
         clip_embed = clip_out.hidden_states[-2]
@@ -412,7 +412,7 @@ class PrecomputedTextLatentDiffusion(ComposerModel):
         batch_size = len(text_embeddings)  # len prompts * num_images_per_prompt
         # classifier free guidance + negative prompts
         # negative prompt is given in place of the unconditional input in classifier free guidance
-        if not neg_prompt_embeds:
+        if neg_prompt_embeds is None:
             # Negative prompt is empty and we want to zero it out
             neg_prompt_embeds = torch.zeros_like(text_embeddings)
             pooled_neg_prompt = torch.zeros_like(pooled_embeddings)

--- a/diffusion/models/precomputed_text_latent_diffusion.py
+++ b/diffusion/models/precomputed_text_latent_diffusion.py
@@ -24,7 +24,7 @@ except:
     is_xformers_installed = False
 
 
-class DiffusionV1(ComposerModel):
+class PrecomputedTextLatentDiffusion(ComposerModel):
     """Diffusion ComposerModel for running with precomputed T5 and CLIP embeddings.
 
     This is a Latent Diffusion model conditioned on text prompts that are run through
@@ -136,7 +136,7 @@ class DiffusionV1(ComposerModel):
         self.clip_position_embedding = torch.nn.Parameter(clip_position_embeddings, requires_grad=True)
 
     def _apply(self, fn):
-        super(DiffusionV1, self)._apply(fn)
+        super(PrecomputedTextLatentDiffusion, self)._apply(fn)
         self.latent_mean = fn(self.latent_mean)
         self.latent_std = fn(self.latent_std)
         return self

--- a/diffusion/models/precomputed_text_latent_diffusion.py
+++ b/diffusion/models/precomputed_text_latent_diffusion.py
@@ -460,9 +460,11 @@ class PrecomputedTextLatentDiffusion(ComposerModel):
         for t in tqdm(self.inference_scheduler.timesteps, disable=not progress_bar):
             latent_model_input = torch.cat([latents] * 2)
             latent_model_input = self.inference_scheduler.scale_model_input(latent_model_input, t)
+            # Make timestep
+            timestep = t.unsqueeze(0).repeat(latent_model_input.shape[0]).to(device)
             # Model prediction
             pred = self.unet(latent_model_input,
-                             t,
+                             timestep,
                              encoder_hidden_states=text_embeddings,
                              encoder_attention_mask=encoder_attn_mask,
                              added_cond_kwargs=added_cond_kwargs).sample

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -125,6 +125,9 @@ class DiffusionV1(ComposerModel):
         # Projection layers for the text embeddings
         self.clip_proj = nn.Linear(768, text_embed_dim)
         self.t5_proj = nn.Linear(4096, text_embed_dim)
+        # Layernorms for the text embeddings
+        self.clip_ln = nn.LayerNorm(text_embed_dim)
+        self.t5_ln = nn.LayerNorm(text_embed_dim)
         # Learnable position embeddings for the conitioning sequences
         t5_position_embeddings = torch.randn(self.max_seq_len, text_embed_dim)
         t5_position_embeddings /= math.sqrt(text_embed_dim)
@@ -219,6 +222,9 @@ class DiffusionV1(ComposerModel):
         # Add position embeddings
         t5_embed = 0.707 * t5_embed + 0.707 * self.t5_position_embedding[:t5_embed.shape[1]].unsqueeze(0)
         clip_embed = 0.707 * clip_embed + 0.707 * self.clip_position_embedding[:clip_embed.shape[1]].unsqueeze(0)
+        # Apply layernorms
+        t5_embed = self.t5_ln(t5_embed)
+        clip_embed = self.clip_ln(clip_embed)
         # Concatenate the text embeddings
         text_embeds = torch.cat([t5_embed, clip_embed], dim=1)
         encoder_attention_mask = torch.cat([t5_mask, clip_mask], dim=1)

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -1,0 +1,612 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diffusion models."""
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from composer.devices import DeviceGPU
+from composer.models import ComposerModel
+from composer.utils import dist
+from diffusers import AutoencoderKL, DDIMScheduler, DDPMScheduler, EulerDiscreteScheduler, UNet2DConditionModel
+from scipy.stats import qmc
+from torchmetrics import MeanSquaredError
+from tqdm.auto import tqdm
+from transformers import PretrainedConfig
+
+from diffusion.models.autoencoder import AutoEncoder, load_autoencoder
+from diffusion.models.layers import zero_module
+from diffusion.models.models import _parse_latent_statistics
+
+try:
+    import xformers  # type: ignore
+    del xformers
+    is_xformers_installed = True
+except:
+    is_xformers_installed = False
+
+
+class DiffusionV1(ComposerModel):
+    """Stable Diffusion ComposerModel.
+
+    This is a Latent Diffusion model conditioned on text prompts that are run through
+    a pre-trained CLIP or LLM model. The CLIP outputs are then passed to as an
+    additional input to our Unet during training and can later be used to guide
+    the image generation process.
+
+    Args:
+        unet (torch.nn.Module): HuggingFace conditional unet, must accept a
+            (B, C, H, W) input, (B,) timestep array of noise timesteps,
+            and (B, 77, 768) text conditioning vectors.
+        vae (torch.nn.Module): HuggingFace or compatible vae.
+            must support `.encode()` and `decode()` functions.
+        noise_scheduler (diffusers.SchedulerMixin): HuggingFace diffusers
+            noise scheduler. Used during the forward diffusion process (training).
+        inference_scheduler (diffusers.SchedulerMixin): HuggingFace diffusers
+            noise scheduler. Used during the backward diffusion process (inference).
+        loss_fn (torch.nn.Module): torch loss function. Default: `F.mse_loss`.
+        prediction_type (str): The type of prediction to use. Must be one of 'sample',
+            'epsilon', or 'v_prediction'. Default: `epsilon`.
+        latent_mean (Optional[tuple[float]]): The means of the latent space. If not specified, defaults to
+            . Default: ``(0.0,) * 4``.
+        latent_std (Optional[tuple[float]]): The standard deviations of the latent space. Default: ``(1/0.13025,)*4``.
+        downsample_factor (int): The factor by which the image is downsampled by the autoencoder. Default `8`.
+        train_metrics (list): List of torchmetrics to calculate during training.
+            Default: `None`.
+        val_metrics (list): List of torchmetrics to calculate during validation.
+            Default: `None`.
+        quasirandomness (bool): Whether to use quasirandomness for generating diffusion process noise.
+            Default: `False`.
+        train_seed (int): Seed to use for generating diffusion process noise during training if using
+            quasirandomness. Default: `42`.
+        val_seed (int): Seed to use for generating eval images. Default: `1138`.
+        fsdp (bool): whether to use FSDP, Default: `False`.
+    """
+
+    def __init__(
+        self,
+        unet,
+        vae,
+        noise_scheduler,
+        inference_noise_scheduler,
+        loss_fn=F.mse_loss,
+        prediction_type: str = 'epsilon',
+        latent_mean: Tuple[float] = (0.0,) * 4,
+        latent_std: Tuple[float] = (1 / 0.13025,) * 4,
+        downsample_factor: int = 8,
+        train_metrics: Optional[List] = None,
+        val_metrics: Optional[List] = None,
+        quasirandomness: bool = False,
+        train_seed: int = 42,
+        val_seed: int = 1138,
+        text_embed_dim: int = 4096,
+        fsdp: bool = False,
+    ):
+        super().__init__()
+        self.unet = unet
+        self.vae = vae
+        self.noise_scheduler = noise_scheduler
+        self.loss_fn = loss_fn
+        self.prediction_type = prediction_type.lower()
+        if self.prediction_type not in ['sample', 'epsilon', 'v_prediction']:
+            raise ValueError(f'prediction type must be one of sample, epsilon, or v_prediction. Got {prediction_type}')
+        self.downsample_factor = downsample_factor
+        self.quasirandomness = quasirandomness
+        self.train_seed = train_seed
+        self.val_seed = val_seed
+        self.latent_mean = latent_mean
+        self.latent_std = latent_std
+        self.latent_mean = torch.tensor(latent_mean).view(1, -1, 1, 1)
+        self.latent_std = torch.tensor(latent_std).view(1, -1, 1, 1)
+        self.train_metrics = train_metrics if train_metrics is not None else [MeanSquaredError()]
+        self.val_metrics = val_metrics if val_metrics is not None else [MeanSquaredError()]
+        self.inference_scheduler = inference_noise_scheduler
+        # freeze VAE during diffusion training
+        self.vae.requires_grad_(False)
+        self.vae = self.vae.half()
+        if fsdp:
+            # only wrap models we are training
+            self.vae._fsdp_wrap = False
+            self.unet._fsdp_wrap = True
+
+        # Optional rng generator
+        self.rng_generator: Optional[torch.Generator] = None
+        if self.quasirandomness:
+            self.sobol = qmc.Sobol(d=1, scramble=True, seed=self.train_seed)
+
+        self.clip_proj = nn.Linear(768, text_embed_dim)
+        self.t5_proj = nn.Linear(4096, text_embed_dim)
+
+    def _apply(self, fn):
+        super(DiffusionV1, self)._apply(fn)
+        self.latent_mean = fn(self.latent_mean)
+        self.latent_std = fn(self.latent_std)
+        return self
+
+    def _generate_timesteps(self, latents: torch.Tensor):
+        if self.quasirandomness:
+            # Generate a quasirandom sequence of timesteps equal to the global batch size
+            global_batch_size = latents.shape[0] * dist.get_world_size()
+            sampled_fractions = torch.tensor(self.sobol.random(global_batch_size), device=latents.device)
+            timesteps = (len(self.noise_scheduler) * sampled_fractions).squeeze()
+            timesteps = torch.floor(timesteps).long()
+            # Get this device's subset of all the timesteps
+            idx_offset = dist.get_global_rank() * latents.shape[0]
+            timesteps = timesteps[idx_offset:idx_offset + latents.shape[0]].to(latents.device)
+        else:
+            timesteps = torch.randint(0,
+                                      len(self.noise_scheduler), (latents.shape[0],),
+                                      device=latents.device,
+                                      generator=self.rng_generator)
+        return timesteps
+
+    def set_rng_generator(self, rng_generator: torch.Generator):
+        """Sets the rng generator for the model."""
+        self.rng_generator = rng_generator
+
+    def forward(self, batch):
+        latents, text_embeds, text_pooled_embeds, encoder_attention_mask = None, None, None, None
+
+        inputs = batch['image']
+        with torch.cuda.amp.autocast(enabled=False):
+            latents = self.vae.encode(inputs.half())['latent_dist'].sample().data
+        latents = (latents - self.latent_mean) / self.latent_std  # scale latents
+
+        t5_embed = self.t5_proj(batch['T5_LATENTS'])
+        clip_embed = self.clip_proj(batch['CLIP_LATENTS'])
+        text_embeds = torch.cat([t5_embed, clip_embed], dim=1)
+        text_pooled_embeds = batch['CLIP_POOLED']
+
+        encoder_attention_mask = torch.cat([batch['T5_ATTENTION_MASK'], batch['CLIP_ATTENTION_MASK']], dim=1)
+
+        # Sample the diffusion timesteps
+        timesteps = self._generate_timesteps(latents)
+        # Add noise to the inputs (forward diffusion)
+        noise = torch.randn(*latents.shape, device=latents.device, generator=self.rng_generator)
+        noised_latents = self.noise_scheduler.add_noise(latents, noise, timesteps)
+        # Generate the targets
+        if self.prediction_type == 'epsilon':
+            targets = noise
+        elif self.prediction_type == 'sample':
+            targets = latents
+        elif self.prediction_type == 'v_prediction':
+            targets = self.noise_scheduler.get_velocity(latents, noise, timesteps)
+        else:
+            raise ValueError(
+                f'prediction type must be one of sample, epsilon, or v_prediction. Got {self.prediction_type}')
+
+        # Prepare added time ids & embeddings
+        add_time_ids = torch.cat(
+            [batch['cond_original_size'], batch['cond_crops_coords_top_left'], batch['cond_target_size']], dim=1)
+        added_cond_kwargs = {'text_embeds': text_pooled_embeds, 'time_ids': add_time_ids}
+
+        # Forward through the model
+        return self.unet(noised_latents,
+                         timesteps,
+                         text_embeds,
+                         encoder_attention_mask=encoder_attention_mask,
+                         added_cond_kwargs=added_cond_kwargs)['sample'], targets, timesteps
+
+    def loss(self, outputs, batch):
+        """Loss between unet output and added noise, typically mse."""
+        return self.loss_fn(outputs[0], outputs[1])
+
+    def eval_forward(self, batch, outputs=None):
+        """For stable diffusion, eval forward computes unet outputs as well as some samples."""
+        # Skip this if outputs have already been computed, e.g. during training
+        if outputs is not None:
+            return outputs
+        return self.forward(batch)
+
+    def get_metrics(self, is_train: bool = False):
+        if is_train:
+            metrics = self.train_metrics
+        else:
+            metrics = self.val_metrics
+        metrics_dict = {metric.__class__.__name__: metric for metric in metrics}
+        return metrics_dict
+
+    def update_metric(self, batch, outputs, metric):
+        metric.update(outputs[0], outputs[1])
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt_embeds: torch.FloatTensor,
+        pooled_prompt: torch.FloatTensor,
+        prompt_mask: torch.LongTensor,
+        neg_prompt_embeds: Optional[torch.FloatTensor] = None,
+        pooled_neg_prompt: Optional[torch.FloatTensor] = None,
+        neg_prompt_mask: Optional[torch.LongTensor] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_inference_steps: Optional[int] = 50,
+        guidance_scale: Optional[float] = 3.0,
+        rescaled_guidance: Optional[float] = None,
+        num_images_per_prompt: Optional[int] = 1,
+        seed: Optional[int] = None,
+        progress_bar: Optional[bool] = True,
+        crop_params: Optional[torch.Tensor] = None,
+        input_size_params: Optional[torch.Tensor] = None,
+    ):
+        """Generates image from noise.
+
+        Performs the backward diffusion process, each inference step takes
+        one forward pass through the unet.
+
+        Args:
+            prompt (str or List[str]): The prompt or prompts to guide the image generation.
+            negative_prompt (str or List[str]): The prompt or prompts to guide the
+                image generation away from. Ignored when not using guidance
+                (i.e., ignored if guidance_scale is less than 1).
+                Must be the same length as list of prompts. Default: `None`.
+            tokenized_prompts (torch.LongTensor): Optionally pass pre-tokenized prompts instead
+                of string prompts. If SDXL, this will be a tensor of size [B, 2, max_length],
+                otherwise will be of shape [B, max_length]. Default: `None`.
+            tokenized_negative_prompts (torch.LongTensor): Optionally pass pre-tokenized negative
+                prompts instead of string prompts. Default: `None`.
+            tokenized_prompts_pad_mask (torch.LongTensor): Optionally pass padding mask for
+                pre-tokenized prompts. Default `None`.
+            tokenized_negative_prompts_pad_mask (torch.LongTensor): Optionall pass padding mask for
+                pre-tokenized negative prompts. Default `None`.
+            prompt_embeds (torch.FloatTensor): Optionally pass pre-tokenized prompts instead
+                of string prompts. If both prompt and prompt_embeds
+                are passed, prompt_embeds will be used. Default: `None`.
+            neg_prompt_embeds (torch.FloatTensor): Optionally pass pre-embedded negative
+                prompts instead of string negative prompts. If both negative_prompt and
+                negative_prompt_embeds are passed, prompt_embeds will be used.  Default: `None`.
+            height (int, optional): The height in pixels of the generated image.
+                Default: `self.unet.config.sample_size * 8)`.
+            width (int, optional): The width in pixels of the generated image.
+                Default: `self.unet.config.sample_size * 8)`.
+            num_inference_steps (int): The number of denoising steps.
+                More denoising steps usually lead to a higher quality image at the expense
+                of slower inference. Default: `50`.
+            guidance_scale (float): Guidance scale as defined in
+                Classifier-Free Diffusion Guidance. guidance_scale is defined as w of equation
+                2. of Imagen Paper. Guidance scale is enabled by setting guidance_scale > 1.
+                Higher guidance scale encourages to generate images that are closely linked
+                to the text prompt, usually at the expense of lower image quality.
+                Default: `3.0`.
+            rescaled_guidance (float, optional): Rescaled guidance scale. If not specified, rescaled guidance will
+                not be used. Default: `None`.
+            num_images_per_prompt (int): The number of images to generate per prompt.
+                 Default: `1`.
+            progress_bar (bool): Whether to use the tqdm progress bar during generation.
+                Default: `True`.
+            seed (int): Random seed to use for generation. Set a seed for reproducible generation.
+                Default: `None`.
+            crop_params (torch.FloatTensor of size [Bx2], optional): Crop parameters to use
+                when generating images with SDXL. Default: `None`.
+            input_size_params (torch.FloatTensor of size [Bx2], optional): Size parameters
+                (representing original size of input image) to use when generating images with SDXL.
+                Default: `None`.
+        """
+        # TODO: do checks
+        # if prompt_embeds.shape[:2] == prompt_mask.shape[:2]:
+        #     raise ValueError(' ')
+
+        # Check all parts of negative prompts exist and are equal length
+        # if neg_prompt_embeds is not None or neg_prompt_mask is not None or pooled_neg_prompt is not None:
+
+        # if negative_negative_embedlen(prompt_embeds) != len(negative_prompt_embeds):
+        #     raise ValueError('len(prompts) and len(negative_prompts) must be the same. \
+        #             A negative prompt must be provided for each given prompt.')
+
+        # Create rng for the generation
+        device = self.vae.device
+        rng_generator = torch.Generator(device=device)
+        if seed:
+            rng_generator = rng_generator.manual_seed(seed)  # type: ignore
+
+        if height is None:
+            height = self.unet.config.sample_size * self.downsample_factor
+        if width is None:
+            width = self.unet.config.sample_size * self.downsample_factor
+
+        do_classifier_free_guidance = guidance_scale > 1.0  # type: ignore
+
+        text_embeddings = _duplicate_tensor(prompt_embeds, num_images_per_prompt)
+        pooled_embeddings = _duplicate_tensor(pooled_prompt, num_images_per_prompt)
+        encoder_attn_mask = _duplicate_tensor(prompt_mask, num_images_per_prompt)
+
+        batch_size = len(prompt_embeds)  # len prompts * num_images_per_prompt
+        # classifier free guidance + negative prompts
+        # negative prompt is given in place of the unconditional input in classifier free guidance
+        if do_classifier_free_guidance:
+            if not neg_prompt_embeds:
+                # Negative prompt is empty and we want to zero it out
+                neg_prompt_embeds = torch.zeros_like(text_embeddings)
+                pooled_neg_prompt = torch.zeros_like(pooled_embeddings)
+                neg_prompt_mask = torch.zeros_like(encoder_attn_mask)
+            else:
+                neg_prompt_embeds = _duplicate_tensor(neg_prompt_embeds, num_images_per_prompt)
+                pooled_neg_prompt = _duplicate_tensor(pooled_neg_prompt, num_images_per_prompt)
+                neg_prompt_mask = _duplicate_tensor(neg_prompt_mask, num_images_per_prompt)
+
+            # concat uncond + prompt
+            text_embeddings = torch.cat([neg_prompt_embeds, text_embeddings])
+            pooled_embeddings = torch.cat([pooled_neg_prompt, pooled_embeddings])
+            encoder_attn_mask = torch.cat([neg_prompt_mask, encoder_attn_mask])
+
+        # prepare for diffusion generation process
+        latents = torch.randn(
+            (batch_size, self.unet.config.in_channels, height // self.downsample_factor,
+             width // self.downsample_factor),
+            device=device,
+            dtype=self.unet.dtype,
+            generator=rng_generator,
+        )
+
+        self.inference_scheduler.set_timesteps(num_inference_steps)
+        # scale the initial noise by the standard deviation required by the scheduler
+        latents = latents * self.inference_scheduler.init_noise_sigma
+
+        added_cond_kwargs = {}
+        # if using SDXL, prepare added time ids & embeddings
+
+        if crop_params is None:
+            crop_params = torch.zeros((batch_size, 2), dtype=text_embeddings.dtype)
+        if input_size_params is None:
+            input_size_params = torch.tensor([[width, height]] * batch_size, dtype=text_embeddings.dtype)
+        output_size_params = torch.tensor([[width, height]] * batch_size, dtype=text_embeddings.dtype)
+
+        if do_classifier_free_guidance:
+            crop_params = torch.cat([crop_params, crop_params])
+            input_size_params = torch.cat([input_size_params, input_size_params])
+            output_size_params = torch.cat([output_size_params, output_size_params])
+
+        add_time_ids = torch.cat([input_size_params, crop_params, output_size_params], dim=1).to(device)
+        added_cond_kwargs = {'text_embeds': pooled_embeddings, 'time_ids': add_time_ids}
+
+        # backward diffusion process
+        for t in tqdm(self.inference_scheduler.timesteps, disable=not progress_bar):
+            if do_classifier_free_guidance:
+                latent_model_input = torch.cat([latents] * 2)
+            else:
+                latent_model_input = latents
+
+            latent_model_input = self.inference_scheduler.scale_model_input(latent_model_input, t)
+            # Model prediction
+            pred = self.unet(latent_model_input,
+                             t,
+                             encoder_hidden_states=text_embeddings,
+                             encoder_attention_mask=encoder_attn_mask,
+                             added_cond_kwargs=added_cond_kwargs).sample
+
+            if do_classifier_free_guidance:
+                # perform guidance. Note this is only techincally correct for prediction_type 'epsilon'
+                pred_uncond, pred_text = pred.chunk(2)
+                pred = pred_uncond + guidance_scale * (pred_text - pred_uncond)
+                # Optionally rescale the classifer free guidance
+                if rescaled_guidance is not None:
+                    std_pos = torch.std(pred_text, dim=(1, 2, 3), keepdim=True)
+                    std_cfg = torch.std(pred, dim=(1, 2, 3), keepdim=True)
+                    pred_rescaled = pred * (std_pos / std_cfg)
+                    pred = pred_rescaled * rescaled_guidance + pred * (1 - rescaled_guidance)
+            # compute the previous noisy sample x_t -> x_t-1
+            latents = self.inference_scheduler.step(pred, t, latents, generator=rng_generator).prev_sample
+
+        # We now use the vae to decode the generated latents back into the image.
+        # scale and decode the image latents with vae
+        latents = latents * self.latent_std + self.latent_mean
+        image = self.vae.decode(latents).sample
+        image = (image / 2 + 0.5).clamp(0, 1)
+        return image.detach()  # (batch*num_images_per_prompt, channel, h, w)
+
+
+def _duplicate_tensor(tensor, num_images_per_prompt):
+    """Duplicate tensor for multiple generations from a single prompt."""
+    batch_size, seq_len = tensor.shape[:2]
+    tensor = tensor.repeat(1, num_images_per_prompt, *[
+        1,
+    ] * len(tensor.shape[2:]))
+    return tensor.view(batch_size * num_images_per_prompt, seq_len, *[
+        -1,
+    ] * len(tensor.shape[2:]))
+
+
+def build_diffusion_v1(
+    unet_model_name: str = 'stabilityai/stable-diffusion-xl-base-1.0',
+    vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
+    autoencoder_path: Optional[str] = None,
+    autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
+    prediction_type: str = 'epsilon',
+    latent_mean: Union[float, Tuple, str] = 0.0,
+    latent_std: Union[float, Tuple, str] = 7.67754318618,
+    text_embed_dim: int = 4096,
+    beta_schedule: str = 'scaled_linear',
+    zero_terminal_snr: bool = False,
+    train_metrics: Optional[List] = None,
+    val_metrics: Optional[List] = None,
+    quasirandomness: bool = False,
+    train_seed: int = 42,
+    val_seed: int = 1138,
+    fsdp: bool = True,
+    use_xformers: bool = True,
+):
+    """Stable diffusion 2 training setup + SDXL UNet and VAE.
+
+    Requires batches of matched images and text prompts to train. Generates images from text
+    prompts. Currently uses UNet and VAE config from SDXL, but text encoder/tokenizer from SD2.
+
+    Args:
+        unet_model_name (str): Name of the UNet model to load. Defaults to
+            'stabilityai/stable-diffusion-xl-base-1.0'.
+        vae_model_name (str): Name of the VAE model to load. Defaults to
+            'madebyollin/sdxl-vae-fp16-fix' as the official VAE checkpoint (from
+            'stabilityai/stable-diffusion-xl-base-1.0') is not compatible with fp16.
+        autoencoder_path (optional, str): Path to autoencoder weights if using custom autoencoder. If not specified,
+            will use the vae from `model_name`. Default `None`.
+        autoencoder_local_path (optional, str): Path to autoencoder weights. Default: `/tmp/autoencoder_weights.pt`.
+        prediction_type (str): The type of prediction to use. Must be one of 'sample',
+            'epsilon', or 'v_prediction'. Default: `epsilon`.
+        latent_mean (float, Tuple, str): The mean of the autoencoder latents. Either a float for a single value,
+            a tuple of means, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `0.0`.
+        latent_std (float, Tuple, str): The std. dev. of the autoencoder latents. Either a float for a single value,
+            a tuple of std_devs, or or `'latent_statistics'` to try to use the value from the autoencoder
+            checkpoint. Defaults to `1/0.13025`.
+        beta_schedule (str): The beta schedule to use. Must be one of 'scaled_linear', 'linear', or 'squaredcos_cap_v2'.
+            Default: `scaled_linear`.
+        zero_terminal_snr (bool): Whether to enforce zero terminal SNR. Default: `False`.
+        train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
+            [MeanSquaredError()].
+        val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
+            [MeanSquaredError()].
+        quasirandomness (bool): Whether to use quasirandomness for generating diffusion process noise.
+            Default: `False`.
+        train_seed (int): Seed to use for generating diffusion process noise during training if using
+            quasirandomness. Default: `42`.
+        val_seed (int): Seed to use for generating evaluation images. Defaults to 1138.
+        fsdp (bool): Whether to use FSDP. Defaults to True.
+        use_xformers (bool): Whether to use xformers for attention. Defaults to True.
+    """
+    latent_mean, latent_std = _parse_latent_statistics(latent_mean), _parse_latent_statistics(latent_std)
+
+    if train_metrics is None:
+        train_metrics = [MeanSquaredError()]
+    if val_metrics is None:
+        val_metrics = [MeanSquaredError()]
+
+    # Make the autoencoder
+    if autoencoder_path is None:
+        if latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
+            raise ValueError('Cannot use tracked latent_statistics when using the pretrained vae.')
+        downsample_factor = 8
+        # Use the pretrained vae
+        try:
+            vae = AutoencoderKL.from_pretrained(vae_model_name, subfolder='vae', torch_dtype=torch.float16)
+        except:  # for handling SDXL vae fp16 fixed checkpoint
+            vae = AutoencoderKL.from_pretrained(vae_model_name, torch_dtype=torch.float16)
+    else:
+        # Use a custom autoencoder
+        vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=torch.float16)
+        if latent_statistics is None and (latent_mean == 'latent_statistics' or latent_std == 'latent_statistics'):
+            raise ValueError(
+                'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
+        if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_mean = tuple(latent_statistics['latent_channel_means'])
+        if isinstance(latent_std, str) and latent_std == 'latent_statistics':
+            assert isinstance(latent_statistics, dict)
+            latent_std = tuple(latent_statistics['latent_channel_stds'])
+        downsample_factor = 2**(len(vae.config['channel_multipliers']) - 1)
+
+    # Make the unet
+    unet_config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')[0]
+
+    if isinstance(vae, AutoEncoder):
+        # Adapt the unet config to account for differing number of latent channels if necessary
+        unet_config['in_channels'] = vae.config['latent_channels']
+        unet_config['out_channels'] = vae.config['latent_channels']
+    unet_config['cross_attention_dim'] = text_embed_dim
+    # This config variable is the sum of the text encoder projection dimension (768 for CLIP) and
+    # the number of additional time embeddings (6) * addition_time_embed_dim (256)
+    unet_config['projection_class_embeddings_input_dim'] = 2304
+    # Init the unet from the config
+    unet = UNet2DConditionModel(**unet_config)
+
+    # Zero initialization trick
+    for name, layer in unet.named_modules():
+        # Final conv in ResNet blocks
+        if name.endswith('conv2'):
+            layer = zero_module(layer)
+        # proj_out in attention blocks
+        if name.endswith('to_out.0'):
+            layer = zero_module(layer)
+    # Last conv block out projection
+    unet.conv_out = zero_module(unet.conv_out)
+
+    if isinstance(latent_mean, float):
+        latent_mean = (latent_mean,) * unet_config['in_channels']
+    if isinstance(latent_std, float):
+        latent_std = (latent_std,) * unet_config['in_channels']
+    assert isinstance(latent_mean, tuple) and isinstance(latent_std, tuple)
+
+    # FSDP Wrapping Scheme
+    if hasattr(unet, 'mid_block') and unet.mid_block is not None:
+        for attention in unet.mid_block.attentions:
+            attention._fsdp_wrap = True
+        for resnet in unet.mid_block.resnets:
+            resnet._fsdp_wrap = True
+    for block in unet.up_blocks:
+        if hasattr(block, 'attentions'):
+            for attention in block.attentions:
+                attention._fsdp_wrap = True
+        if hasattr(block, 'resnets'):
+            for resnet in block.resnets:
+                resnet._fsdp_wrap = True
+    for block in unet.down_blocks:
+        if hasattr(block, 'attentions'):
+            for attention in block.attentions:
+                attention._fsdp_wrap = True
+        if hasattr(block, 'resnets'):
+            for resnet in block.resnets:
+                resnet._fsdp_wrap = True
+
+    # Make the noise schedulers
+    noise_scheduler = DDPMScheduler(num_train_timesteps=1000,
+                                    beta_start=0.00085,
+                                    beta_end=0.012,
+                                    beta_schedule=beta_schedule,
+                                    trained_betas=None,
+                                    variance_type='fixed_small',
+                                    clip_sample=False,
+                                    prediction_type=prediction_type,
+                                    sample_max_value=1.0,
+                                    timestep_spacing='leading',
+                                    steps_offset=1,
+                                    rescale_betas_zero_snr=zero_terminal_snr)
+    if beta_schedule == 'squaredcos_cap_v2':
+        inference_noise_scheduler = DDIMScheduler(num_train_timesteps=1000,
+                                                  beta_start=0.00085,
+                                                  beta_end=0.012,
+                                                  beta_schedule=beta_schedule,
+                                                  trained_betas=None,
+                                                  clip_sample=False,
+                                                  set_alpha_to_one=False,
+                                                  prediction_type=prediction_type,
+                                                  rescale_betas_zero_snr=zero_terminal_snr)
+    else:
+        inference_noise_scheduler = EulerDiscreteScheduler(num_train_timesteps=1000,
+                                                           beta_start=0.00085,
+                                                           beta_end=0.012,
+                                                           beta_schedule=beta_schedule,
+                                                           trained_betas=None,
+                                                           prediction_type=prediction_type,
+                                                           interpolation_type='linear',
+                                                           use_karras_sigmas=False,
+                                                           timestep_spacing='leading',
+                                                           steps_offset=1,
+                                                           rescale_betas_zero_snr=zero_terminal_snr)
+
+    # Make the composer model
+    model = DiffusionV1(
+        unet=unet,
+        vae=vae,
+        noise_scheduler=noise_scheduler,
+        inference_noise_scheduler=inference_noise_scheduler,
+        prediction_type=prediction_type,
+        latent_mean=latent_mean,
+        latent_std=latent_std,
+        downsample_factor=downsample_factor,
+        train_metrics=train_metrics,
+        val_metrics=val_metrics,
+        quasirandomness=quasirandomness,
+        train_seed=train_seed,
+        val_seed=val_seed,
+        text_embed_dim=text_embed_dim,
+        fsdp=fsdp,
+    )
+    if torch.cuda.is_available():
+        model = DeviceGPU().module_to_device(model)
+        if is_xformers_installed and use_xformers:
+            model.unet.enable_xformers_memory_efficient_attention()
+            if hasattr(model.vae, 'enable_xformers_memory_efficient_attention'):
+                model.vae.enable_xformers_memory_efficient_attention()
+
+    return model

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -143,7 +143,7 @@ class DiffusionV1(ComposerModel):
         if not self.unet.training:
             # Sample equally spaced timesteps across all devices
             global_batch_size = latents.shape[0] * dist.get_world_size()
-            global_timesteps = torch.linspace(0, len(self.noise_scheduler), global_batch_size).to(torch.int64)
+            global_timesteps = torch.linspace(0, len(self.noise_scheduler) - 1, global_batch_size).to(torch.int64)
             # Get this device's subset of all the timesteps
             idx_offset = dist.get_global_rank() * latents.shape[0]
             timesteps = global_timesteps[idx_offset:idx_offset + latents.shape[0]].to(latents.device)

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -381,8 +381,6 @@ class DiffusionV1(ComposerModel):
             raise ValueError('pooled_prompt should be provided if and only if using embeddings')
         if (prompt_mask is None) != (prompt_embeds is None):
             raise ValueError('prompt_mask should be provided if and only if using embeddings')
-        if (neg_prompt_embeds is None) == (negative_prompt is None):
-            raise ValueError('One and only one of negative_prompt or neg_prompt_embeds should be provided.')
         if (neg_prompt_mask is None) != (neg_prompt_embeds is None):
             raise ValueError('neg_prompt_mask should be provided if and only if using embeddings')
         if (pooled_neg_prompt is None) != (neg_prompt_embeds is None):

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -4,23 +4,17 @@
 """Diffusion models."""
 
 import math
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from composer.devices import DeviceGPU
 from composer.models import ComposerModel
 from composer.utils import dist
-from diffusers import AutoencoderKL, DDIMScheduler, DDPMScheduler, EulerDiscreteScheduler, UNet2DConditionModel
 from scipy.stats import qmc
 from torchmetrics import MeanSquaredError
 from tqdm.auto import tqdm
-from transformers import PretrainedConfig
-
-from diffusion.models.autoencoder import AutoEncoder, load_autoencoder
-from diffusion.models.layers import zero_module
-from diffusion.models.models import _parse_latent_statistics
+from transformers import PreTrainedTokenizer
 
 try:
     import xformers  # type: ignore
@@ -77,10 +71,10 @@ class DiffusionV1(ComposerModel):
         vae,
         noise_scheduler,
         inference_noise_scheduler,
-        t5_tokenizer: Optional = None,
-        t5_encoder: Optional = None,
-        clip_tokenizer: Optional = None,
-        clip_encoder: Optional = None,
+        t5_tokenizer: Optional[PreTrainedTokenizer] = None,
+        t5_encoder: Optional[torch.nn.Module] = None,
+        clip_tokenizer: Optional[PreTrainedTokenizer] = None,
+        clip_encoder: Optional[torch.nn.Module] = None,
         prediction_type: str = 'epsilon',
         latent_mean: Tuple[float] = (0.0,) * 4,
         latent_std: Tuple[float] = (1 / 0.13025,) * 4,
@@ -110,8 +104,6 @@ class DiffusionV1(ComposerModel):
         self.quasirandomness = quasirandomness
         self.train_seed = train_seed
         self.val_seed = val_seed
-        self.latent_mean = latent_mean
-        self.latent_std = latent_std
         self.latent_mean = torch.tensor(latent_mean).view(1, -1, 1, 1)
         self.latent_std = torch.tensor(latent_std).view(1, -1, 1, 1)
         self.train_metrics = train_metrics if train_metrics is not None else [MeanSquaredError()]
@@ -148,7 +140,7 @@ class DiffusionV1(ComposerModel):
         return self
 
     def _generate_timesteps(self, latents: torch.Tensor):
-        if not self.model.training:
+        if not self.unet.training:
             # Sample equally spaced timesteps across all devices
             global_batch_size = latents.shape[0] * dist.get_world_size()
             global_timesteps = torch.linspace(0, len(self.noise_scheduler), global_batch_size)
@@ -167,9 +159,9 @@ class DiffusionV1(ComposerModel):
                 timesteps = timesteps[idx_offset:idx_offset + latents.shape[0]].to(latents.device)
             else:
                 timesteps = torch.randint(0,
-                                        len(self.noise_scheduler), (latents.shape[0],),
-                                        device=latents.device,
-                                        generator=self.rng_generator)
+                                          len(self.noise_scheduler), (latents.shape[0],),
+                                          device=latents.device,
+                                          generator=self.rng_generator)
         return timesteps
 
     def set_rng_generator(self, rng_generator: torch.Generator):
@@ -187,7 +179,34 @@ class DiffusionV1(ComposerModel):
         image = self.vae.decode(latents).sample
         image = (image / 2 + 0.5).clamp(0, 1)
         return image
-        
+
+    def encode_text(self, text, device):
+        assert self.t5_tokenizer is not None and self.t5_encoder is not None
+        assert self.clip_tokenizer is not None and self.clip_encoder is not None
+        # Encode with T5
+        t5_tokenizer_out = self.t5_tokenizer(text,
+                                             padding='max_length',
+                                             max_length=self.t5_tokenizer.model_max_length,
+                                             truncation=True,
+                                             return_tensors='pt')
+        tokenized_captions = t5_tokenizer_out['input_ids'].to(device)
+        t5_attn_mask = t5_tokenizer_out['attention_mask'].to(torch.bool).to(device)
+        t5_embed = self.t5_encoder(input_ids=tokenized_captions, attention_mask=t5_attn_mask)
+        # Encode with CLIP
+        clip_tokenizer_out = self.clip_tokenizer(text,
+                                                 padding='max_length',
+                                                 max_length=self.clip_tokenizer.model_max_length,
+                                                 truncation=True,
+                                                 return_tensors='pt')
+        tokenized_captions = clip_tokenizer_out['input_ids'].to(device)
+        clip_attn_mask = clip_tokenizer_out['attention_mask'].to(torch.bool).to(device)
+        clip_out = self.clip_encoder(input_ids=tokenized_captions,
+                                     attention_mask=clip_attn_mask,
+                                     output_hidden_states=True)
+        clip_embed = clip_out.hidden_states[-2]
+        pooled_embeddings = clip_out[1]
+        return t5_embed, clip_embed, t5_attn_mask, clip_attn_mask, pooled_embeddings
+
     def prepare_text_embeddings(self, t5_embed, clip_embed, t5_mask, clip_mask):
         if t5_embed.shape[1] > self.max_seq_len:
             t5_embed = t5_embed[:, :self.max_seq_len]
@@ -278,9 +297,11 @@ class DiffusionV1(ComposerModel):
     @torch.no_grad()
     def generate(
         self,
-        prompt_embeds: torch.FloatTensor,
-        pooled_prompt: torch.FloatTensor,
-        prompt_mask: torch.LongTensor,
+        prompt: Optional[list] = None,
+        negative_prompt: Optional[list] = None,
+        prompt_embeds: Optional[torch.FloatTensor] = None,
+        pooled_prompt: Optional[torch.FloatTensor] = None,
+        prompt_mask: Optional[torch.LongTensor] = None,
         neg_prompt_embeds: Optional[torch.FloatTensor] = None,
         pooled_neg_prompt: Optional[torch.FloatTensor] = None,
         neg_prompt_mask: Optional[torch.LongTensor] = None,
@@ -301,20 +322,11 @@ class DiffusionV1(ComposerModel):
         one forward pass through the unet.
 
         Args:
-            prompt (str or List[str]): The prompt or prompts to guide the image generation.
+            prompt (List[str]): The prompts to guide the image generation.
             negative_prompt (str or List[str]): The prompt or prompts to guide the
                 image generation away from. Ignored when not using guidance
                 (i.e., ignored if guidance_scale is less than 1).
                 Must be the same length as list of prompts. Default: `None`.
-            tokenized_prompts (torch.LongTensor): Optionally pass pre-tokenized prompts instead
-                of string prompts. If SDXL, this will be a tensor of size [B, 2, max_length],
-                otherwise will be of shape [B, max_length]. Default: `None`.
-            tokenized_negative_prompts (torch.LongTensor): Optionally pass pre-tokenized negative
-                prompts instead of string prompts. Default: `None`.
-            tokenized_prompts_pad_mask (torch.LongTensor): Optionally pass padding mask for
-                pre-tokenized prompts. Default `None`.
-            tokenized_negative_prompts_pad_mask (torch.LongTensor): Optionall pass padding mask for
-                pre-tokenized negative prompts. Default `None`.
             prompt_embeds (torch.FloatTensor): Optionally pass pre-tokenized prompts instead
                 of string prompts. If both prompt and prompt_embeds
                 are passed, prompt_embeds will be used. Default: `None`.
@@ -348,17 +360,6 @@ class DiffusionV1(ComposerModel):
                 (representing original size of input image) to use when generating images with SDXL.
                 Default: `None`.
         """
-        # TODO: do checks
-        # if prompt_embeds.shape[:2] == prompt_mask.shape[:2]:
-        #     raise ValueError(' ')
-
-        # Check all parts of negative prompts exist and are equal length
-        # if neg_prompt_embeds is not None or neg_prompt_mask is not None or pooled_neg_prompt is not None:
-
-        # if negative_negative_embedlen(prompt_embeds) != len(negative_prompt_embeds):
-        #     raise ValueError('len(prompts) and len(negative_prompts) must be the same. \
-        #             A negative prompt must be provided for each given prompt.')
-
         # Create rng for the generation
         device = self.vae.device
         rng_generator = torch.Generator(device=device)
@@ -371,6 +372,34 @@ class DiffusionV1(ComposerModel):
             width = self.unet.config.sample_size * self.downsample_factor
 
         do_classifier_free_guidance = guidance_scale > 1.0  # type: ignore
+
+        # Check that inputs are consistent with all embeddings or text inputs. All embeddings should be provided if using
+        # embeddings, and none if using text.
+        if (prompt_embeds is None) == (prompt is None):
+            raise ValueError('One and only one of prompt or prompt_embeds should be provided.')
+        if (pooled_prompt is None) != (prompt_embeds is None):
+            raise ValueError('pooled_prompt should be provided if and only if using embeddings')
+        if (prompt_mask is None) != (prompt_embeds is None):
+            raise ValueError('prompt_mask should be provided if and only if using embeddings')
+        if (neg_prompt_embeds is None) == (negative_prompt is None):
+            raise ValueError('One and only one of negative_prompt or neg_prompt_embeds should be provided.')
+        if (neg_prompt_mask is None) != (neg_prompt_embeds is None):
+            raise ValueError('neg_prompt_mask should be provided if and only if using embeddings')
+        if (pooled_neg_prompt is None) != (neg_prompt_embeds is None):
+            raise ValueError('pooled_neg_prompt should be provided if and only if using embeddings')
+
+        # If the prompt is specified as text, encode it.
+        if prompt is not None:
+            t5_embed, clip_embed, t5_attn_mask, clip_attn_mask, pooled_prompt = self.encode_text(
+                prompt, self.vae.device)
+            prompt_embeds, prompt_mask = self.prepare_text_embeddings(t5_embed, clip_embed, t5_attn_mask,
+                                                                      clip_attn_mask)
+        # If negative prompt is specified as text, encode it.
+        if negative_prompt is not None:
+            t5_embed, clip_embed, t5_attn_mask, clip_attn_mask, pooled_neg_prompt = self.encode_text(
+                negative_prompt, self.vae.device)
+            neg_prompt_embeds, neg_prompt_mask = self.prepare_text_embeddings(t5_embed, clip_embed, t5_attn_mask,
+                                                                              clip_attn_mask)
 
         text_embeddings = _duplicate_tensor(prompt_embeds, num_images_per_prompt)
         pooled_embeddings = _duplicate_tensor(pooled_prompt, num_images_per_prompt)
@@ -468,206 +497,3 @@ def _duplicate_tensor(tensor, num_images_per_prompt):
     return tensor.view(batch_size * num_images_per_prompt, seq_len, *[
         -1,
     ] * len(tensor.shape[2:]))
-
-
-def build_diffusion_v1(
-    unet_model_name: str = 'stabilityai/stable-diffusion-xl-base-1.0',
-    vae_model_name: str = 'madebyollin/sdxl-vae-fp16-fix',
-    autoencoder_path: Optional[str] = None,
-    autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
-    prediction_type: str = 'epsilon',
-    latent_mean: Union[float, Tuple, str] = 0.0,
-    latent_std: Union[float, Tuple, str] = 7.67754318618,
-    text_embed_dim: int = 4096,
-    beta_schedule: str = 'scaled_linear',
-    zero_terminal_snr: bool = False,
-    train_metrics: Optional[List] = None,
-    val_metrics: Optional[List] = None,
-    quasirandomness: bool = False,
-    train_seed: int = 42,
-    val_seed: int = 1138,
-    fsdp: bool = True,
-    use_xformers: bool = True,
-):
-    """Stable diffusion 2 training setup + SDXL UNet and VAE.
-
-    Requires batches of matched images and text prompts to train. Generates images from text
-    prompts. Currently uses UNet and VAE config from SDXL, but text encoder/tokenizer from SD2.
-
-    Args:
-        unet_model_name (str): Name of the UNet model to load. Defaults to
-            'stabilityai/stable-diffusion-xl-base-1.0'.
-        vae_model_name (str): Name of the VAE model to load. Defaults to
-            'madebyollin/sdxl-vae-fp16-fix' as the official VAE checkpoint (from
-            'stabilityai/stable-diffusion-xl-base-1.0') is not compatible with fp16.
-        autoencoder_path (optional, str): Path to autoencoder weights if using custom autoencoder. If not specified,
-            will use the vae from `model_name`. Default `None`.
-        autoencoder_local_path (optional, str): Path to autoencoder weights. Default: `/tmp/autoencoder_weights.pt`.
-        prediction_type (str): The type of prediction to use. Must be one of 'sample',
-            'epsilon', or 'v_prediction'. Default: `epsilon`.
-        latent_mean (float, Tuple, str): The mean of the autoencoder latents. Either a float for a single value,
-            a tuple of means, or or `'latent_statistics'` to try to use the value from the autoencoder
-            checkpoint. Defaults to `0.0`.
-        latent_std (float, Tuple, str): The std. dev. of the autoencoder latents. Either a float for a single value,
-            a tuple of std_devs, or or `'latent_statistics'` to try to use the value from the autoencoder
-            checkpoint. Defaults to `1/0.13025`.
-        beta_schedule (str): The beta schedule to use. Must be one of 'scaled_linear', 'linear', or 'squaredcos_cap_v2'.
-            Default: `scaled_linear`.
-        zero_terminal_snr (bool): Whether to enforce zero terminal SNR. Default: `False`.
-        train_metrics (list, optional): List of metrics to compute during training. If None, defaults to
-            [MeanSquaredError()].
-        val_metrics (list, optional): List of metrics to compute during validation. If None, defaults to
-            [MeanSquaredError()].
-        quasirandomness (bool): Whether to use quasirandomness for generating diffusion process noise.
-            Default: `False`.
-        train_seed (int): Seed to use for generating diffusion process noise during training if using
-            quasirandomness. Default: `42`.
-        val_seed (int): Seed to use for generating evaluation images. Defaults to 1138.
-        fsdp (bool): Whether to use FSDP. Defaults to True.
-        use_xformers (bool): Whether to use xformers for attention. Defaults to True.
-    """
-    latent_mean, latent_std = _parse_latent_statistics(latent_mean), _parse_latent_statistics(latent_std)
-
-    if train_metrics is None:
-        train_metrics = [MeanSquaredError()]
-    if val_metrics is None:
-        val_metrics = [MeanSquaredError()]
-
-    # Make the autoencoder
-    if autoencoder_path is None:
-        if latent_mean == 'latent_statistics' or latent_std == 'latent_statistics':
-            raise ValueError('Cannot use tracked latent_statistics when using the pretrained vae.')
-        downsample_factor = 8
-        # Use the pretrained vae
-        try:
-            vae = AutoencoderKL.from_pretrained(vae_model_name, subfolder='vae', torch_dtype=torch.float16)
-        except:  # for handling SDXL vae fp16 fixed checkpoint
-            vae = AutoencoderKL.from_pretrained(vae_model_name, torch_dtype=torch.float16)
-    else:
-        # Use a custom autoencoder
-        vae, latent_statistics = load_autoencoder(autoencoder_path, autoencoder_local_path, torch_dtype=torch.float16)
-        if latent_statistics is None and (latent_mean == 'latent_statistics' or latent_std == 'latent_statistics'):
-            raise ValueError(
-                'Must specify latent scale when using a custom autoencoder without tracking latent statistics.')
-        if isinstance(latent_mean, str) and latent_mean == 'latent_statistics':
-            assert isinstance(latent_statistics, dict)
-            latent_mean = tuple(latent_statistics['latent_channel_means'])
-        if isinstance(latent_std, str) and latent_std == 'latent_statistics':
-            assert isinstance(latent_statistics, dict)
-            latent_std = tuple(latent_statistics['latent_channel_stds'])
-        downsample_factor = 2**(len(vae.config['channel_multipliers']) - 1)
-
-    # Make the unet
-    unet_config = PretrainedConfig.get_config_dict(unet_model_name, subfolder='unet')[0]
-
-    if isinstance(vae, AutoEncoder):
-        # Adapt the unet config to account for differing number of latent channels if necessary
-        unet_config['in_channels'] = vae.config['latent_channels']
-        unet_config['out_channels'] = vae.config['latent_channels']
-    unet_config['cross_attention_dim'] = text_embed_dim
-    # This config variable is the sum of the text encoder projection dimension (768 for CLIP) and
-    # the number of additional time embeddings (6) * addition_time_embed_dim (256)
-    unet_config['projection_class_embeddings_input_dim'] = 2304
-    # Init the unet from the config
-    unet = UNet2DConditionModel(**unet_config)
-
-    # Zero initialization trick
-    for name, layer in unet.named_modules():
-        # Final conv in ResNet blocks
-        if name.endswith('conv2'):
-            layer = zero_module(layer)
-        # proj_out in attention blocks
-        if name.endswith('to_out.0'):
-            layer = zero_module(layer)
-    # Last conv block out projection
-    unet.conv_out = zero_module(unet.conv_out)
-
-    if isinstance(latent_mean, float):
-        latent_mean = (latent_mean,) * unet_config['in_channels']
-    if isinstance(latent_std, float):
-        latent_std = (latent_std,) * unet_config['in_channels']
-    assert isinstance(latent_mean, tuple) and isinstance(latent_std, tuple)
-
-    # FSDP Wrapping Scheme
-    if hasattr(unet, 'mid_block') and unet.mid_block is not None:
-        for attention in unet.mid_block.attentions:
-            attention._fsdp_wrap = True
-        for resnet in unet.mid_block.resnets:
-            resnet._fsdp_wrap = True
-    for block in unet.up_blocks:
-        if hasattr(block, 'attentions'):
-            for attention in block.attentions:
-                attention._fsdp_wrap = True
-        if hasattr(block, 'resnets'):
-            for resnet in block.resnets:
-                resnet._fsdp_wrap = True
-    for block in unet.down_blocks:
-        if hasattr(block, 'attentions'):
-            for attention in block.attentions:
-                attention._fsdp_wrap = True
-        if hasattr(block, 'resnets'):
-            for resnet in block.resnets:
-                resnet._fsdp_wrap = True
-
-    # Make the noise schedulers
-    noise_scheduler = DDPMScheduler(num_train_timesteps=1000,
-                                    beta_start=0.00085,
-                                    beta_end=0.012,
-                                    beta_schedule=beta_schedule,
-                                    trained_betas=None,
-                                    variance_type='fixed_small',
-                                    clip_sample=False,
-                                    prediction_type=prediction_type,
-                                    sample_max_value=1.0,
-                                    timestep_spacing='leading',
-                                    steps_offset=1,
-                                    rescale_betas_zero_snr=zero_terminal_snr)
-    if beta_schedule == 'squaredcos_cap_v2':
-        inference_noise_scheduler = DDIMScheduler(num_train_timesteps=1000,
-                                                  beta_start=0.00085,
-                                                  beta_end=0.012,
-                                                  beta_schedule=beta_schedule,
-                                                  trained_betas=None,
-                                                  clip_sample=False,
-                                                  set_alpha_to_one=False,
-                                                  prediction_type=prediction_type,
-                                                  rescale_betas_zero_snr=zero_terminal_snr)
-    else:
-        inference_noise_scheduler = EulerDiscreteScheduler(num_train_timesteps=1000,
-                                                           beta_start=0.00085,
-                                                           beta_end=0.012,
-                                                           beta_schedule=beta_schedule,
-                                                           trained_betas=None,
-                                                           prediction_type=prediction_type,
-                                                           interpolation_type='linear',
-                                                           use_karras_sigmas=False,
-                                                           timestep_spacing='leading',
-                                                           steps_offset=1,
-                                                           rescale_betas_zero_snr=zero_terminal_snr)
-
-    # Make the composer model
-    model = DiffusionV1(
-        unet=unet,
-        vae=vae,
-        noise_scheduler=noise_scheduler,
-        inference_noise_scheduler=inference_noise_scheduler,
-        prediction_type=prediction_type,
-        latent_mean=latent_mean,
-        latent_std=latent_std,
-        downsample_factor=downsample_factor,
-        train_metrics=train_metrics,
-        val_metrics=val_metrics,
-        quasirandomness=quasirandomness,
-        train_seed=train_seed,
-        val_seed=val_seed,
-        text_embed_dim=text_embed_dim,
-        fsdp=fsdp,
-    )
-    if torch.cuda.is_available():
-        model = DeviceGPU().module_to_device(model)
-        if is_xformers_installed and use_xformers:
-            model.unet.enable_xformers_memory_efficient_attention()
-            if hasattr(model.vae, 'enable_xformers_memory_efficient_attention'):
-                model.vae.enable_xformers_memory_efficient_attention()
-
-    return model

--- a/diffusion/models/t5_diffusion.py
+++ b/diffusion/models/t5_diffusion.py
@@ -143,7 +143,7 @@ class DiffusionV1(ComposerModel):
         if not self.unet.training:
             # Sample equally spaced timesteps across all devices
             global_batch_size = latents.shape[0] * dist.get_world_size()
-            global_timesteps = torch.linspace(0, len(self.noise_scheduler), global_batch_size)
+            global_timesteps = torch.linspace(0, len(self.noise_scheduler), global_batch_size).to(torch.int64)
             # Get this device's subset of all the timesteps
             idx_offset = dist.get_global_rank() * latents.shape[0]
             timesteps = global_timesteps[idx_offset:idx_offset + latents.shape[0]].to(latents.device)


### PR DESCRIPTION
This PR adds a model class for running with precomputed text latents. It is largely similar to the SDXL model, with the exception of concatenating latents from the different text encoders along a sequence dimension rather than a feature dimension after projecting to a common embedding dimension. 

This builds off of [152](https://github.com/mosaicml/diffusion/pull/152) which can now be closed.