### PR TITLE
Various transformer updates to improve performance

### DIFF
--- a/diffusion/callbacks/log_diffusion_images.py
+++ b/diffusion/callbacks/log_diffusion_images.py
@@ -37,6 +37,7 @@ class LogDiffusionImages(Callback):
         seed (int, optional): Random seed to use for generation. Set a seed for reproducible generation.
             Default: ``1138``.
         use_table (bool): Whether to make a table of the images or not. Default: ``False``.
+        use_mask (bool): Whether or not to use the mask for the encoded text. Default: ``True``.
         t5_encoder (str, optional): path to the T5 encoder to as a second text encoder.
         clip_encoder (str, optional): path to the CLIP encoder as the first text encoder.
         t5_latent_key: (str): key to use for the T5 latents in the batch. Default: ``'T5_LATENTS'``.
@@ -56,6 +57,7 @@ class LogDiffusionImages(Callback):
                  rescaled_guidance: Optional[float] = None,
                  seed: Optional[int] = 1138,
                  use_table: bool = False,
+                 use_mask: bool = True,
                  t5_encoder: Optional[str] = None,
                  clip_encoder: Optional[str] = None,
                  t5_latent_key: str = 'T5_LATENTS',
@@ -71,6 +73,7 @@ class LogDiffusionImages(Callback):
         self.rescaled_guidance = rescaled_guidance
         self.seed = seed
         self.use_table = use_table
+        self.use_mask = use_mask
         self.t5_latent_key = t5_latent_key
         self.t5_mask_key = t5_mask_key
         self.clip_latent_key = clip_latent_key
@@ -100,12 +103,12 @@ class LogDiffusionImages(Callback):
                                                            local_files_only=True)
 
             t5_model = AutoModel.from_pretrained(t5_encoder,
-                                                 torch_dtype=torch.float16,
+                                                 torch_dtype=torch.bfloat16,
                                                  cache_dir=self.cache_dir,
                                                  local_files_only=True).encoder.cuda().eval()
             clip_model = CLIPTextModel.from_pretrained(clip_encoder,
                                                        subfolder='text_encoder',
-                                                       torch_dtype=torch.float16,
+                                                       torch_dtype=torch.bfloat16,
                                                        cache_dir=self.cache_dir,
                                                        local_files_only=True).cuda().eval()
 
@@ -160,21 +163,40 @@ class LogDiffusionImages(Callback):
             if self.precomputed_latents:
                 for batch in self.batched_latents:
                     pooled_prompt = batch[self.clip_pooled_key].cuda()
-                    prompt_embeds, prompt_mask = model.prepare_text_embeddings(batch[self.t5_latent_key].cuda(),
-                                                                               batch[self.clip_latent_key].cuda(),
-                                                                               batch[self.t5_mask_key].cuda(),
-                                                                               batch[self.clip_mask_key].cuda())
-                    gen_images = model.generate(prompt_embeds=prompt_embeds,
-                                                pooled_prompt=pooled_prompt,
-                                                prompt_mask=prompt_mask,
-                                                height=self.size[0],
-                                                width=self.size[1],
-                                                guidance_scale=self.guidance_scale,
-                                                rescaled_guidance=self.rescaled_guidance,
-                                                progress_bar=False,
-                                                num_inference_steps=self.num_inference_steps,
-                                                seed=self.seed)
+                    if self.use_mask:
+                        prompt_embeds, prompt_mask = model.prepare_text_embeddings(batch[self.t5_latent_key].cuda(),
+                                                                                   batch[self.clip_latent_key].cuda(),
+                                                                                   batch[self.t5_mask_key].cuda(),
+                                                                                   batch[self.clip_mask_key].cuda())
+                        gen_images = model.generate(prompt_embeds=prompt_embeds,
+                                                    pooled_prompt=pooled_prompt,
+                                                    prompt_mask=prompt_mask,
+                                                    height=self.size[0],
+                                                    width=self.size[1],
+                                                    guidance_scale=self.guidance_scale,
+                                                    rescaled_guidance=self.rescaled_guidance,
+                                                    progress_bar=False,
+                                                    num_inference_steps=self.num_inference_steps,
+                                                    seed=self.seed)
+                    else:
+                        prompt_embeds = model.prepare_text_embeddings(batch[self.t5_latent_key].cuda(),
+                                                                      batch[self.clip_latent_key].cuda())
+                        gen_images = model.generate(prompt_embeds=prompt_embeds,
+                                                    pooled_prompt=pooled_prompt,
+                                                    height=self.size[0],
+                                                    width=self.size[1],
+                                                    guidance_scale=self.guidance_scale,
+                                                    rescaled_guidance=self.rescaled_guidance,
+                                                    progress_bar=False,
+                                                    num_inference_steps=self.num_inference_steps,
+                                                    seed=self.seed)
                     all_gen_images.append(gen_images)
+                    # Clear up GPU tensors
+                    del pooled_prompt
+                    del prompt_embeds
+                    if self.use_mask:
+                        del prompt_mask
+                    torch.cuda.empty_cache()
             else:
                 for batch in self.batched_prompts:
                     gen_images = model.generate(

--- a/diffusion/datasets/synthetic_image_caption_latents.py
+++ b/diffusion/datasets/synthetic_image_caption_latents.py
@@ -1,0 +1,91 @@
+# Copyright 2022 MosaicML Diffusion authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Synthetic Image-Caption dataset."""
+
+from typing import Dict, Optional
+
+import torch
+from composer.utils import dist
+from torch.utils.data import DataLoader, Dataset
+
+
+class SyntheticImageCaptionLatentsDataset(Dataset):
+    """Synthetic dataset imitating a dataset containing image-caption pairs.
+
+    Args:
+        image_size (int): Size of the synthetic images. Default: ``512``.
+        clip_length (int): Length of the synthetic clip embeddings. Default: ``77``.
+        clip_dim (int): Dimension of the synthetic clip embeddings. Default: ``768``.
+        t5_length (int): Length of the synthetic T5 embeddings. Default: ``512``.
+        t5_dim (int): Dimension of the synthetic T5 embeddings. Default: ``4096``.
+    """
+
+    def __init__(self,
+                 image_size: int = 512,
+                 clip_length: int = 77,
+                 clip_dim: int = 768,
+                 t5_length: int = 512,
+                 t5_dim: int = 4096):
+
+        super().__init__()
+        self.image_size = image_size
+        self.clip_length = clip_length
+        self.clip_dim = clip_dim
+        self.t5_length = t5_length
+        self.t5_dim = t5_dim
+
+    def __len__(self):
+        return 100_000
+
+    def __getitem__(self, idx):
+        out = {}
+        out['cond_crops_coords_top_left'] = torch.tensor([0, 0], dtype=torch.float)
+        out['cond_original_size'] = torch.tensor([self.image_size, self.image_size], dtype=torch.float)
+        out['cond_target_size'] = torch.tensor([self.image_size, self.image_size], dtype=torch.float)
+        out['image'] = torch.randn(3, self.image_size, self.image_size)
+        out['CLIP_LATENTS'] = torch.randn(self.clip_length, self.clip_dim, dtype=torch.float)
+        out['CLIP_POOLED'] = torch.randn(self.clip_dim, dtype=torch.float)
+        out['CLIP_ATTENTION_MASK'] = torch.ones(self.clip_length)
+        out['T5_LATENTS'] = torch.randn(self.t5_length, self.t5_dim, dtype=torch.float)
+        out['T5_ATTENTION_MASK'] = torch.ones(self.t5_length)
+        return out
+
+
+def build_synthetic_image_caption_latents_dataloader(
+    batch_size: int,
+    image_size: int = 512,
+    clip_length: int = 77,
+    clip_dim: int = 768,
+    t5_length: int = 512,
+    t5_dim: int = 4096,
+    dataloader_kwargs: Optional[Dict] = None,
+):
+    """Builds a dataloader for the synthetic image-caption dataset.
+
+    Args:
+        batch_size (int): Batch size for the dataloader.
+        image_size (int): Size of the synthetic images. Default: ``512``.
+        clip_length (int): Length of the synthetic clip embeddings. Default: ``77``.
+        clip_dim (int): Dimension of the synthetic clip embeddings. Default: ``768``.
+        t5_length (int): Length of the synthetic T5 embeddings. Default: ``512``.
+        t5_dim (int): Dimension of the synthetic T5 embeddings. Default: ``4096``.
+        dataloader_kwargs (optional, dict): Additional arguments to pass to the dataloader. Default ``None``.
+    """
+    if dataloader_kwargs is None:
+        dataloader_kwargs = {}
+
+    dataset = SyntheticImageCaptionLatentsDataset(image_size=image_size,
+                                                  clip_length=clip_length,
+                                                  clip_dim=clip_dim,
+                                                  t5_length=t5_length,
+                                                  t5_dim=t5_dim)
+
+    dataloader = DataLoader(
+        dataset=dataset,
+        sampler=dist.get_sampler(dataset),
+        batch_size=batch_size,
+        **dataloader_kwargs,
+    )
+
+    return dataloader

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -902,7 +902,6 @@ def text_to_image_transformer(
     timestep_shift: float = 1.0,
     image_key: str = 'image',
     caption_key: str = 'captions',
-    caption_mask_key: str = 'attention_mask',
     pretrained: bool = False,
 ):
     """Text to image transformer training setup.
@@ -940,7 +939,6 @@ def text_to_image_transformer(
         timestep_shift (float): The shift of the timesteps. Default: `1.0`.
         image_key (str): The key for the image in the batch. Default: `image`.
         caption_key (str): The key for the captions in the batch. Default: `captions`.
-        caption_mask_key (str): The key for the caption mask in the batch. Default: `attention_mask`.
         pretrained (bool): Whether to load pretrained weights. Not used. Defaults to False.
     """
     latent_mean, latent_std = _parse_latent_statistics(latent_mean), _parse_latent_statistics(latent_std)
@@ -1018,8 +1016,7 @@ def text_to_image_transformer(
                                      timestep_std=timestep_std,
                                      timestep_shift=timestep_shift,
                                      image_key=image_key,
-                                     caption_key=caption_key,
-                                     caption_mask_key=caption_mask_key)
+                                     caption_key=caption_key)
 
     if torch.cuda.is_available():
         model = DeviceGPU().module_to_device(model)
@@ -1050,9 +1047,7 @@ def precomputed_text_latents_to_image_transformer(
     timestep_shift: float = 1.0,
     image_key: str = 'image',
     t5_latent_key: str = 'T5_LATENTS',
-    t5_mask_key: str = 'T5_ATTENTION_MASK',
     clip_latent_key: str = 'CLIP_LATENTS',
-    clip_mask_key: str = 'CLIP_ATTENTION_MASK',
     clip_pooled_key: str = 'CLIP_POOLED',
     pretrained: bool = False,
 ):
@@ -1189,9 +1184,7 @@ def precomputed_text_latents_to_image_transformer(
                                                        timestep_shift=timestep_shift,
                                                        image_key=image_key,
                                                        t5_latent_key=t5_latent_key,
-                                                       t5_mask_key=t5_mask_key,
                                                        clip_latent_key=clip_latent_key,
-                                                       clip_mask_key=clip_mask_key,
                                                        clip_pooled_key=clip_pooled_key)
 
     if torch.cuda.is_available():

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -886,6 +886,7 @@ def text_to_image_transformer(
     autoencoder_path: Optional[str] = None,
     autoencoder_local_path: str = '/tmp/autoencoder_weights.pt',
     num_layers: int = 28,
+    attention_implementation: Optional[str] = None,
     max_image_side: int = 1280,
     conditioning_features: int = 768,
     conditioning_max_sequence_length: int = 77,
@@ -913,6 +914,8 @@ def text_to_image_transformer(
         autoencoder_local_path (optional, str): Path to autoencoder weights. Default: `/tmp/autoencoder_weights.pt`.
         num_layers (int): Number of layers in the transformer. Number of heads and layer width are determined by
             this according to `num_features = 64 * num_layers`, and `num_heads = num_layers`. Default: `28`.
+        attention_implementation (optional, str): Attention implementation. One of ('flash', 'mem_efficient', 'math').
+            If not specified, will let SDPA decide. Default: 'None'.
         max_image_side (int): Maximum side length of the image. Default: `1280`.
         conditioning_features (int): Number of features in the conditioning transformer. Default: `768`.
         conditioning_max_sequence_length (int): Maximum sequence length for the conditioning transformer. Default: `77`.
@@ -979,6 +982,7 @@ def text_to_image_transformer(
     transformer = DiffusionTransformer(num_features=64 * num_layers,
                                        num_heads=num_layers,
                                        num_layers=num_layers,
+                                       attention_implementation=attention_implementation,
                                        input_features=autoencoder_channels * (patch_size**2),
                                        input_max_sequence_length=input_max_sequence_length,
                                        input_dimension=2,
@@ -1020,6 +1024,7 @@ def precomputed_text_latents_to_image_transformer(
     conditioning_features: int = 768,
     conditioning_max_sequence_length: int = 512 + 77,
     num_register_tokens: int = 0,
+    attention_implementation: Optional[str] = None,
     patch_size: int = 2,
     latent_mean: Union[float, Tuple, str] = 0.0,
     latent_std: Union[float, Tuple, str] = 7.67754318618,
@@ -1052,6 +1057,8 @@ def precomputed_text_latents_to_image_transformer(
         conditioning_features (int): Number of features in the conditioning transformer. Default: `768`.
         conditioning_max_sequence_length (int): Maximum sequence length for the conditioning transformer. Default: `77`.
         num_register_tokens (int): Number of additional register tokens to use. Default: `0`.
+        attention_implementation (optional, str): Attention implementation. One of ('flash', 'mem_efficient', 'math').
+            If not specified, will let SDPA decide. Default: 'None'.
         patch_size (int): Patch size for the transformer. Default: `2`.
         latent_mean (float, Tuple, str): The mean of the autoencoder latents. Either a float for a single value,
             a tuple of means, or or `'latent_statistics'` to try to use the value from the autoencoder
@@ -1110,6 +1117,7 @@ def precomputed_text_latents_to_image_transformer(
     transformer = DiffusionTransformer(num_features=64 * num_layers,
                                        num_heads=num_layers,
                                        num_layers=num_layers,
+                                       attention_implementation=attention_implementation,
                                        input_features=autoencoder_channels * (patch_size**2),
                                        input_max_sequence_length=input_max_sequence_length,
                                        input_dimension=2,

--- a/diffusion/models/t2i_transformer.py
+++ b/diffusion/models/t2i_transformer.py
@@ -569,7 +569,7 @@ class ComposerPrecomputedTextLatentsToImageMMDiT(ComposerModel):
         self.autoencoder = self.autoencoder.half()
 
         # Only FSDP wrap models we are training
-        self.model._fsdp_wrap = False
+        self.model._fsdp_wrap = True
         self.autoencoder._fsdp_wrap = False
 
         # Param counts relevant for MFU computation

--- a/diffusion/models/transformer.py
+++ b/diffusion/models/transformer.py
@@ -32,13 +32,17 @@ def get_multidimensional_position_embeddings(position_embeddings: torch.Tensor, 
     Returns:
         torch.Tensor: Sequenced embeddings of shape (B, S, F, D)
     """
-    B, S, D = coords.shape
-    F = position_embeddings.shape[2]
-    coords = coords.reshape(B * S, D)
-    sequenced_embeddings = [position_embeddings[d, coords[:, d]] for d in range(D)]
-    sequenced_embeddings = torch.stack(sequenced_embeddings, dim=-1)
-    sequenced_embeddings = sequenced_embeddings.view(B, S, F, D)
-    return sequenced_embeddings  # (B, S, F, D)
+    B = coords.shape[0]
+    F = position_embeddings.shape[-1]  # Position embedding dimensions
+    coords = coords.permute(2, 0, 1)  # (D, B, S)
+    position_embeddings = position_embeddings.unsqueeze(1).expand(-1, B, -1, -1)  # (D, B, T, F)
+    # Prepare indices for torch.gather
+    coords = coords.unsqueeze(-1).expand(-1, -1, -1, F)  # (D, B, S, F)
+    # Use torch.gather to collect embeddings
+    embeddings = torch.gather(position_embeddings, 2, coords)  # (D, B, S, F)
+    # Rearrange embeddings to the desired output shape
+    embeddings = embeddings.permute(1, 2, 3, 0)  # (B, S, F, D)
+    return embeddings
 
 
 class AdaptiveLayerNorm(nn.Module):
@@ -55,18 +59,24 @@ class AdaptiveLayerNorm(nn.Module):
         self.num_features = num_features
         # MLP for computing modulations.
         # Initialized to zero so modulation acts as identity at initialization.
-        self.adaLN_mlp_linear = nn.Linear(self.num_features, 2 * self.num_features, bias=True)
-        nn.init.zeros_(self.adaLN_mlp_linear.weight)
-        nn.init.zeros_(self.adaLN_mlp_linear.bias)
-        self.adaLN_mlp = nn.Sequential(nn.SiLU(), self.adaLN_mlp_linear)
+        self.adaLN_mlp_linear_shift = nn.Linear(self.num_features, self.num_features, bias=True)
+        self.adaLN_mlp_linear_scale = nn.Linear(self.num_features, self.num_features, bias=True)
+        nn.init.zeros_(self.adaLN_mlp_linear_shift.weight)
+        nn.init.zeros_(self.adaLN_mlp_linear_scale.weight)
+        nn.init.zeros_(self.adaLN_mlp_linear_shift.bias)
+        nn.init.zeros_(self.adaLN_mlp_linear_scale.bias)
+        self.adaLN_mlp_shift = nn.Sequential(nn.SiLU(), self.adaLN_mlp_linear_shift)
+        self.adaLN_mlp_scale = nn.Sequential(nn.SiLU(), self.adaLN_mlp_linear_scale)
         # LayerNorm
-        self.layernorm = nn.LayerNorm(self.num_features, elementwise_affine=True, eps=1e-6)
+        self.layernorm = nn.LayerNorm(self.num_features, elementwise_affine=False, eps=1e-6)
 
+    @torch.compile()
     def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
         # Calculate the modulations
-        mods = self.adaLN_mlp(t).unsqueeze(1).chunk(2, dim=2)
+        shift = self.adaLN_mlp_linear_shift(t)
+        scale = self.adaLN_mlp_linear_scale(t)
         # Apply the modulations
-        return modulate(self.layernorm(x), mods[0], mods[1])
+        return modulate(self.layernorm(x), shift, scale)
 
 
 class ModulationLayer(nn.Module):
@@ -88,9 +98,10 @@ class ModulationLayer(nn.Module):
         nn.init.zeros_(self.adaLN_mlp_linear.bias)
         self.adaLN_mlp = nn.Sequential(nn.SiLU(), self.adaLN_mlp_linear)
 
+    @torch.compile()
     def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
         # Calculate the modulations
-        mods = self.adaLN_mlp(t).unsqueeze(1)
+        mods = self.adaLN_mlp(t)
         return x * mods
 
 
@@ -102,39 +113,43 @@ class ScalarEmbedding(nn.Module):
     Args:
         num_features (int): The size of the output vector.
         sinusoidal_embedding_dim (int): The size of the intermediate sinusoidal embedding. Default: `256`.
+        max_period (int): The maximum period of the sinusoidal embedding. Default: `10000`.
 
     Returns:
         torch.Tensor: The embedded scalar
     """
 
-    def __init__(self, num_features: int, sinusoidal_embedding_dim: int = 256):
+    def __init__(self, num_features: int, sinusoidal_embedding_dim: int = 256, max_period: int = 10000):
         super().__init__()
         self.num_features = num_features
         self.sinusoidal_embedding_dim = sinusoidal_embedding_dim
+        self.max_period = max_period
         self.linear_1 = nn.Linear(self.sinusoidal_embedding_dim, self.num_features)
         self.linear_2 = nn.Linear(self.num_features, self.num_features)
         self.mlp = nn.Sequential(self.linear_1, nn.SiLU(), self.linear_2)
+        # Make the freqs
+        half_dim = self.sinusoidal_embedding_dim // 2
+        self.freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half_dim, dtype=torch.float32) /
+                               half_dim)
 
-    @staticmethod
-    def timestep_embedding(timesteps: torch.Tensor, dim: int, max_period: int = 10000) -> torch.Tensor:
+    def _apply(self, fn):
+        super(ScalarEmbedding, self)._apply(fn)
+        self.freqs = fn(self.freqs)
+        return self
+
+    def timestep_embedding(self, timesteps: torch.Tensor) -> torch.Tensor:
         """Create sinusoidal timestep embeddings.
 
         Args:
             timesteps (torch.Tensor): The timesteps to embed.
-            dim (int): The size of the output embedding.
-            max_period (int): The maximum period of the sinusoidal embedding. Default: `10000`.
         """
-        half = dim // 2
-        freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) /
-                          half).to(device=timesteps.device)
-        args = timesteps[:, None].float() * freqs[None]
+        args = timesteps[:, None].float() * self.freqs[None]
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
-        if dim % 2:
-            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
         return embedding
 
+    @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        sinusoidal_embedding = self.timestep_embedding(x, self.sinusoidal_embedding_dim)
+        sinusoidal_embedding = self.timestep_embedding(x)
         # Ensure embedding is the correct dtype
         sinusoidal_embedding = sinusoidal_embedding.to(next(self.parameters()).dtype)
         return self.mlp(sinusoidal_embedding)
@@ -158,6 +173,7 @@ class VectorEmbedding(nn.Module):
         self.linear_2 = nn.Linear(self.num_features, self.num_features)
         self.mlp = nn.Sequential(self.linear_1, nn.SiLU(), self.linear_2)
 
+    @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.mlp(x)
 
@@ -177,21 +193,23 @@ class PreAttentionBlock(nn.Module):
         # Adaptive layernorm
         self.adaptive_layernorm = AdaptiveLayerNorm(self.num_features)
         # Linear layer to get q, k, and v
-        self.qkv = nn.Linear(self.num_features, 3 * self.num_features)
+        self.q_proj = nn.Linear(self.num_features, self.num_features)
+        self.k_proj = nn.Linear(self.num_features, self.num_features)
+        self.v_proj = nn.Linear(self.num_features, self.num_features)
         # QK layernorms. Original MMDiT used RMSNorm here.
         self.q_norm = nn.LayerNorm(self.num_features, elementwise_affine=True, eps=1e-6)
         self.k_norm = nn.LayerNorm(self.num_features, elementwise_affine=True, eps=1e-6)
-        # Initialize all biases to zero
-        nn.init.zeros_(self.qkv.bias)
-        # Init the standard deviation of the weights to 0.02 as is tradition
-        nn.init.normal_(self.qkv.weight, std=0.02)
+        for l in [self.q_proj, self.k_proj, self.v_proj]:
+            # Initialize all biases to zero
+            nn.init.zeros_(l.bias)
+            # Init the standard deviation of the weights to 0.02 as is tradition
+            nn.init.normal_(l.weight, std=0.02)
 
+    @torch.compile()
     def forward(self, x: torch.Tensor, t: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         x = self.adaptive_layernorm(x, t)
         # Calculate the query, key, and values all in one go
-        q, k, v = self.qkv(x).chunk(3, dim=-1)
-        q = self.q_norm(q)
-        k = self.k_norm(k)
+        q, k, v = self.q_norm(self.q_proj(x)), self.k_norm(self.k_proj(x)), self.v_proj(x)
         return q, k, v
 
 
@@ -208,6 +226,7 @@ class SelfAttention(nn.Module):
         self.num_features = num_features
         self.num_heads = num_heads
 
+    @torch.compile()
     def forward(self,
                 q: torch.Tensor,
                 k: torch.Tensor,
@@ -258,6 +277,7 @@ class PostAttentionBlock(nn.Module):
         # Output modulation
         self.modulate_output = ModulationLayer(self.num_features)
 
+    @torch.compile()
     def forward(self, v: torch.Tensor, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
         """Forward takes v from self attention and the original sequence x with scalar conditioning t."""
         # Postprocess v with linear + gating modulation
@@ -302,6 +322,7 @@ class MMDiTBlock(nn.Module):
         if not self.is_last:
             self.post_attention_block_2 = PostAttentionBlock(self.num_features, self.expansion_factor)
 
+    @torch.compile()
     def forward(self,
                 x1: torch.Tensor,
                 x2: torch.Tensor,
@@ -445,16 +466,19 @@ class DiffusionTransformer(nn.Module):
         # Optionally add constant conditioning. This assumes it has been embedded already.
         if constant_conditioning is not None:
             t = t + constant_conditioning
+        t = t.unsqueeze(1)
         # Embed the input
         y = self.input_embedding(x)  # (B, T1, C)
         # Get the input position embeddings and add them to the input
         y_position_embeddings = get_multidimensional_position_embeddings(self.input_position_embedding, input_coords)
         y_position_embeddings = y_position_embeddings.sum(dim=-1)  # (B, T1, C)
         y = y + y_position_embeddings  # (B, T1, C)
+        '''
         if input_mask is None:
             mask = torch.ones(x.shape[0], x.shape[1], device=x.device)
         else:
             mask = input_mask
+        '''
 
         # Embed the conditioning
         c = self.conditioning_embedding(conditioning)  # (B, T2, C)
@@ -463,23 +487,28 @@ class DiffusionTransformer(nn.Module):
                                                                          conditioning_coords)
         c_position_embeddings = c_position_embeddings.sum(dim=-1)  # (B, T2, C)
         c = c + c_position_embeddings  # (B, T2, C)
+        '''
         # Concatenate the masks
         if conditioning_mask is None:
             conditioning_mask = torch.ones(conditioning.shape[0], conditioning.shape[1], device=conditioning.device)
         mask = torch.cat([mask, conditioning_mask], dim=1)  # (B, T1 + T2)
+        '''
         # Optionally add the register tokens
         if self.num_register_tokens > 0:
             repeated_register = self.register_tokens.repeat(c.shape[0], 1, 1)
             c = torch.cat([c, repeated_register], dim=1)
-            register_mask = torch.ones(c.shape[0], self.num_register_tokens, device=mask.device)
-            mask = torch.cat([mask, register_mask], dim=1)
+            #register_mask = torch.ones(c.shape[0], self.num_register_tokens, device=mask.device)
+            #mask = torch.cat([mask, register_mask], dim=1)
 
+        '''
         # Expand the mask to the right shape
         mask = mask.bool()
         mask = mask.unsqueeze(-1) & mask.unsqueeze(1)  # (B, T1 + T2, T1 + T2)
         identity = torch.eye(mask.shape[1], device=mask.device, dtype=mask.dtype).unsqueeze(0)
         mask = mask | identity
         mask = mask.unsqueeze(1)  # (B, 1, T1 + T2, T1 + T2)
+        '''
+        mask = None
 
         # Pass through the transformer blocks
         for block in self.transformer_blocks:

--- a/diffusion/models/transformer.py
+++ b/diffusion/models/transformer.py
@@ -639,8 +639,6 @@ class DiffusionTransformer(nn.Module):
                 t: torch.Tensor,
                 conditioning: torch.Tensor,
                 conditioning_coords: torch.Tensor,
-                input_mask: Optional[torch.Tensor] = None,
-                conditioning_mask: Optional[torch.Tensor] = None,
                 constant_conditioning: Optional[torch.Tensor] = None) -> torch.Tensor:
         """Forward pass through the diffusion transformer.
 
@@ -650,8 +648,6 @@ class DiffusionTransformer(nn.Module):
             t (torch.Tensor): The scalar timesteps of shape (B, 1).
             conditioning (torch.Tensor): The conditioning sequence of shape (B, T2, C2).
             conditioning_coords (torch.Tensor): The coordinates of the D dimensional conditioning sequence of shape (B, T2, D).
-            input_mask (Optional[torch.Tensor]): The mask for the input sequence of shape (B, T1).
-            conditioning_mask (Optional[torch.Tensor]): The mask for the conditioning sequence of shape (B, T2).
             constant_conditioning (Optional[torch.Tensor]): Optional additional constant conditioning (B, num_features).
 
         Returns:


### PR DESCRIPTION
This PR includes a few updates and fixes to the diffusion transformer to improve performance

Changes include:
- Various code refactors to avoid some inefficient ops
- Selectable backends for the attention layer
- Option to use both DiT and MMDiT blocks
- Grouping of transformer blocks for more efficient sharding
- Option to add additional register tokens
- Added torch compile
- Remove masking in attention layers as it is an unnecessary slowdown
- Minor fixes to the image logging callback